### PR TITLE
feat: 비디오 다운로드 및 GUI 기능 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **headless=False 유지**: 내장 Chromium에서는 LMS 영상 재생이 실패한다. 반드시 시스템 Chrome + headless=False 조합을 유지할 것.
 - **로그인 플로우 순서 고정**: `login.py`의 SSO 버튼 클릭 → 폼 입력 → 로그인 버튼 클릭 순서는 LMS에 맞춰져 있다. 순서를 바꾸면 로그인이 깨진다.
-- **CDP 스니핑 방식 필수**: `video_parser.py`에서 CDP `Network.requestWillBeSent`로 영상 URL을 가로채는 것이 유일한 방법이다. DOM에서 video src를 직접 추출하는 방식은 동작하지 않는다.
+- **DOM 추출 방식 기본**: `video_parser.py`에서 `video.vc-vplay-video1` 요소의 `src` 속성으로 영상 URL을 추출한다. CDP 스니핑(`CdpVideoExtractor`)은 deprecated fallback으로 유지된다.
 - **`ssmovie.mp4` 패턴**: LMS 서버가 하드코딩한 영상 경로 패턴이다. LMS가 변경하면 같이 바뀌어야 하므로 향후 추상화 대상.
 
 ## 설계 의도
@@ -16,7 +16,6 @@
 
 ## 알려진 버그 (미수정)
 
-- `video_pipeline/pipeline.py`에서 `download_video(save_dir=...)`로 호출하지만, `download_video()` 함수에 `save_dir` 파라미터가 없다.
 - `summarizer.py`에서 `user_setting.OPENAI_API_KEY`를 참조하지만, `UserSetting` 클래스에 해당 속성이 정의되지 않았다.
 - CLI(`src/main.py`)는 상대 import, GUI(`src/gui/`)는 `src.` prefix import를 사용한다. 경로 불일치 주의.
 

--- a/src/gui/config/constants.py
+++ b/src/gui/config/constants.py
@@ -17,6 +17,7 @@ EMOJI_ERROR = "❌"
 EMOJI_WARNING = "⚠️"
 EMOJI_INFO = "📋"
 EMOJI_PROCESSING = "⏳"
+EMOJI_STOP = "⏹"
 
 
 @dataclass(frozen=True)

--- a/src/gui/config/styles.py
+++ b/src/gui/config/styles.py
@@ -122,6 +122,40 @@ class StyleSheet:
         """
 
     @staticmethod
+    def caps_lock_warning() -> str:
+        """Caps Lock 경고 라벨 스타일"""
+        return f"""
+            QLabel {{
+                color: {Colors.WARNING};
+                font-size: 11px;
+                margin-top: 0px;
+                margin-bottom: 5px;
+                padding-left: 12px;
+            }}
+        """
+
+    @staticmethod
+    def stop_button() -> str:
+        """중지 버튼 스타일"""
+        return f"""
+            QPushButton {{
+                background-color: {Colors.ERROR};
+                color: white;
+                border: none;
+                padding: 10px 20px;
+                border-radius: 6px;
+                font-size: 14px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{
+                background-color: #c0392b;
+            }}
+            QPushButton:pressed {{
+                background-color: #a93226;
+            }}
+        """
+
+    @staticmethod
     def path_value() -> str:
         """경로 표시 스타일"""
         return """

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -142,13 +142,5 @@ def load_user_inputs() -> Dict[str, str]:
 
 
 def get_downloads_dir() -> str:
-    """다운로드 디렉토리 경로 반환"""
-    if getattr(sys, 'frozen', False):
-        # .app 번들인 경우 사용자의 Downloads 폴더 사용
-        downloads = os.path.expanduser('~/Downloads/LMS-Summarizer')
-    else:
-        # 개발 환경인 경우 현재 디렉토리의 downloads 폴더 사용
-        downloads = 'downloads'
-
-    Path(downloads).mkdir(parents=True, exist_ok=True)
-    return downloads
+    """다운로드 디렉토리 경로 반환 (사용자 설정 경로 사용)"""
+    return ensure_downloads_directory()

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -126,6 +126,21 @@ def extract_urls_from_input(url_input: str) -> List[str]:
     return urls
 
 
+_PERSISTABLE_FIELDS = ['student_id', 'api_key', 'urls']
+
+
+def save_user_inputs(inputs: Dict[str, str]) -> None:
+    """사용자 입력값을 설정 파일에 저장 (비밀번호 제외)"""
+    settings = load_settings()
+    settings['user_inputs'] = {k: inputs[k] for k in _PERSISTABLE_FIELDS if k in inputs}
+    save_settings(settings)
+
+
+def load_user_inputs() -> Dict[str, str]:
+    """저장된 사용자 입력값 로드"""
+    return load_settings().get('user_inputs', {})
+
+
 def get_downloads_dir() -> str:
     """다운로드 디렉토리 경로 반환"""
     if getattr(sys, 'frozen', False):

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -4,6 +4,7 @@ LMS 강의 다운로드 & 요약 GUI 애플리케이션
 메인 진입점 파일
 """
 
+import signal
 import sys
 import os
 
@@ -68,6 +69,9 @@ def main():
         # 메인 윈도우 생성 및 실행
         window = MainWindow(modules, errors)
         window.show()
+
+        # Ctrl+C로 종료 가능하도록 SIGINT 핸들러 설정
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
 
         sys.exit(app.exec_())
 

--- a/src/gui/ui/components/buttons.py
+++ b/src/gui/ui/components/buttons.py
@@ -6,7 +6,7 @@ from PyQt5.QtWidgets import QPushButton
 from PyQt5.QtCore import pyqtSignal
 
 from src.gui.config.styles import StyleSheet
-from src.gui.config.constants import EMOJI_START, EMOJI_PROCESSING
+from src.gui.config.constants import EMOJI_START, EMOJI_PROCESSING, EMOJI_STOP
 
 
 class ProcessingButton(QPushButton):
@@ -15,20 +15,22 @@ class ProcessingButton(QPushButton):
     def __init__(self, text: str = f"{EMOJI_START} 요약 시작"):
         super().__init__(text)
         self.default_text = text
-        self.processing_text = f"{EMOJI_PROCESSING} 처리 중..."
+        self.stop_text = f"{EMOJI_STOP} 중지"
         self.setStyleSheet(StyleSheet.button())
         self.is_processing = False
 
     def start_processing(self):
-        """처리 시작 상태로 변경"""
+        """처리 시작 → 중지 버튼으로 변경"""
         self.is_processing = True
-        self.setText(self.processing_text)
-        self.setEnabled(False)
+        self.setText(self.stop_text)
+        self.setStyleSheet(StyleSheet.stop_button())
+        self.setEnabled(True)
 
     def stop_processing(self):
-        """처리 완료 상태로 변경"""
+        """처리 완료 → 시작 버튼으로 복원"""
         self.is_processing = False
         self.setText(self.default_text)
+        self.setStyleSheet(StyleSheet.button())
         self.setEnabled(True)
 
     def set_enabled_with_text(self, enabled: bool, text: str = None):

--- a/src/gui/ui/components/input_field.py
+++ b/src/gui/ui/components/input_field.py
@@ -2,11 +2,49 @@
 재사용 가능한 입력 필드 컴포넌트
 """
 
-from PyQt5.QtWidgets import QLabel, QLineEdit, QTextEdit
-from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QLabel, QLineEdit, QTextEdit, QAction
+from PyQt5.QtCore import Qt, pyqtSignal
 
 from src.gui.config.settings import InputFieldConfig
 from src.gui.config.styles import StyleSheet
+
+
+class PasswordLineEdit(QLineEdit):
+    """비밀번호 입력 필드 (보이기/숨기기 토글 + Caps Lock 감지)"""
+
+    caps_lock_changed = pyqtSignal(bool)
+
+    def __init__(self, placeholder: str = ""):
+        super().__init__()
+        self.setPlaceholderText(placeholder)
+        self.setEchoMode(QLineEdit.Password)
+        self._password_visible = False
+        self._setup_toggle_action()
+
+    def _setup_toggle_action(self):
+        """보이기/숨기기 토글 액션 설정"""
+        self._toggle_action = QAction("👁", self)
+        self._toggle_action.triggered.connect(self._toggle_visibility)
+        self.addAction(self._toggle_action, QLineEdit.TrailingPosition)
+
+    def _toggle_visibility(self):
+        """비밀번호 보이기/숨기기 전환"""
+        self._password_visible = not self._password_visible
+        if self._password_visible:
+            self.setEchoMode(QLineEdit.Normal)
+            self._toggle_action.setText("🙈")
+        else:
+            self.setEchoMode(QLineEdit.Password)
+            self._toggle_action.setText("👁")
+
+    def keyPressEvent(self, event):
+        """키 입력 시 Caps Lock 상태 감지"""
+        super().keyPressEvent(event)
+        text = event.text()
+        if text and text.isalpha():
+            shift_pressed = bool(event.modifiers() & Qt.ShiftModifier)
+            caps_on = (text.isupper() and not shift_pressed) or (text.islower() and shift_pressed)
+            self.caps_lock_changed.emit(caps_on)
 
 
 class InputField:
@@ -16,6 +54,10 @@ class InputField:
         self.config = config
         self.label = self._create_label()
         self.widget = self._create_input_widget()
+        self.caps_lock_label = None
+
+        if self.config.is_password:
+            self._setup_caps_lock_label()
 
     def _create_label(self) -> QLabel:
         """라벨 생성"""
@@ -32,13 +74,13 @@ class InputField:
 
     def _create_single_line_input(self) -> QLineEdit:
         """단일 라인 입력 필드 생성"""
-        widget = QLineEdit()
-        widget.setPlaceholderText(self.config.placeholder)
-        widget.setStyleSheet(StyleSheet.input_field())
-
         if self.config.is_password:
-            widget.setEchoMode(QLineEdit.Password)
+            widget = PasswordLineEdit(self.config.placeholder)
+        else:
+            widget = QLineEdit()
+            widget.setPlaceholderText(self.config.placeholder)
 
+        widget.setStyleSheet(StyleSheet.input_field())
         return widget
 
     def _create_multiline_input(self) -> QTextEdit:
@@ -51,6 +93,13 @@ class InputField:
             widget.setMaximumHeight(self.config.max_height)
 
         return widget
+
+    def _setup_caps_lock_label(self):
+        """Caps Lock 경고 라벨 설정"""
+        self.caps_lock_label = QLabel("⚠ Caps Lock이 켜져 있습니다")
+        self.caps_lock_label.setStyleSheet(StyleSheet.caps_lock_warning())
+        self.caps_lock_label.setVisible(False)
+        self.widget.caps_lock_changed.connect(self.caps_lock_label.setVisible)
 
     def get_value(self) -> str:
         """입력값 반환"""

--- a/src/gui/ui/components/input_field.py
+++ b/src/gui/ui/components/input_field.py
@@ -2,49 +2,95 @@
 재사용 가능한 입력 필드 컴포넌트
 """
 
-from PyQt5.QtWidgets import QLabel, QLineEdit, QTextEdit, QAction
+from PyQt5.QtWidgets import QLabel, QLineEdit, QTextEdit, QPushButton, QHBoxLayout, QWidget, QVBoxLayout
 from PyQt5.QtCore import Qt, pyqtSignal
 
 from src.gui.config.settings import InputFieldConfig
 from src.gui.config.styles import StyleSheet
 
 
-class PasswordLineEdit(QLineEdit):
+class PasswordLineEdit(QWidget):
     """비밀번호 입력 필드 (보이기/숨기기 토글 + Caps Lock 감지)"""
 
     caps_lock_changed = pyqtSignal(bool)
 
     def __init__(self, placeholder: str = ""):
         super().__init__()
-        self.setPlaceholderText(placeholder)
-        self.setEchoMode(QLineEdit.Password)
         self._password_visible = False
-        self._setup_toggle_action()
 
-    def _setup_toggle_action(self):
-        """보이기/숨기기 토글 액션 설정"""
-        self._toggle_action = QAction("👁", self)
-        self._toggle_action.triggered.connect(self._toggle_visibility)
-        self.addAction(self._toggle_action, QLineEdit.TrailingPosition)
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
 
-    def _toggle_visibility(self):
-        """비밀번호 보이기/숨기기 전환"""
-        self._password_visible = not self._password_visible
-        if self._password_visible:
-            self.setEchoMode(QLineEdit.Normal)
-            self._toggle_action.setText("🙈")
-        else:
-            self.setEchoMode(QLineEdit.Password)
-            self._toggle_action.setText("👁")
+        # 비밀번호 입력 필드
+        self._input = QLineEdit()
+        self._input.setPlaceholderText(placeholder)
+        self._input.setEchoMode(QLineEdit.Password)
+        layout.addWidget(self._input)
 
-    def keyPressEvent(self, event):
+        # 보이기/숨기기 토글 버튼
+        self._toggle_btn = QPushButton("👁")
+        self._toggle_btn.setFixedSize(36, 36)
+        self._toggle_btn.setCursor(Qt.PointingHandCursor)
+        self._toggle_btn.setStyleSheet("""
+            QPushButton {
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                background-color: white;
+                font-size: 16px;
+                padding: 0px;
+            }
+            QPushButton:hover {
+                background-color: #f0f0f0;
+            }
+        """)
+        self._toggle_btn.clicked.connect(self._toggle_visibility)
+        layout.addWidget(self._toggle_btn)
+
+        self.setLayout(layout)
+
+        # QLineEdit의 keyPressEvent를 가로채서 Caps Lock 감지
+        self._input.keyPressEvent = self._wrapped_key_press
+
+    def _wrapped_key_press(self, event):
         """키 입력 시 Caps Lock 상태 감지"""
-        super().keyPressEvent(event)
+        QLineEdit.keyPressEvent(self._input, event)
         text = event.text()
         if text and text.isalpha():
             shift_pressed = bool(event.modifiers() & Qt.ShiftModifier)
             caps_on = (text.isupper() and not shift_pressed) or (text.islower() and shift_pressed)
             self.caps_lock_changed.emit(caps_on)
+
+    def _toggle_visibility(self):
+        """비밀번호 보이기/숨기기 전환"""
+        self._password_visible = not self._password_visible
+        if self._password_visible:
+            self._input.setEchoMode(QLineEdit.Normal)
+            self._toggle_btn.setText("🙈")
+        else:
+            self._input.setEchoMode(QLineEdit.Password)
+            self._toggle_btn.setText("👁")
+
+    # QLineEdit 호환 인터페이스
+    def text(self) -> str:
+        return self._input.text()
+
+    def setText(self, text: str):
+        self._input.setText(text)
+
+    def clear(self):
+        self._input.clear()
+
+    def setFocus(self):
+        self._input.setFocus()
+
+    def setStyleSheet(self, style: str):
+        self._input.setStyleSheet(style)
+
+    def setEnabled(self, enabled: bool):
+        super().setEnabled(enabled)
+        self._input.setEnabled(enabled)
+        self._toggle_btn.setEnabled(enabled)
 
 
 class InputField:
@@ -72,7 +118,7 @@ class InputField:
         else:
             return self._create_single_line_input()
 
-    def _create_single_line_input(self) -> QLineEdit:
+    def _create_single_line_input(self):
         """단일 라인 입력 필드 생성"""
         if self.config.is_password:
             widget = PasswordLineEdit(self.config.placeholder)
@@ -105,14 +151,14 @@ class InputField:
         """입력값 반환"""
         if hasattr(self.widget, 'toPlainText'):  # QTextEdit
             return self.widget.toPlainText()
-        else:  # QLineEdit
+        else:  # QLineEdit or PasswordLineEdit
             return self.widget.text()
 
     def set_value(self, value: str):
         """입력값 설정"""
         if hasattr(self.widget, 'setPlainText'):  # QTextEdit
             self.widget.setPlainText(value)
-        else:  # QLineEdit
+        else:  # QLineEdit or PasswordLineEdit
             self.widget.setText(value)
 
     def clear(self):

--- a/src/gui/ui/windows/main_window.py
+++ b/src/gui/ui/windows/main_window.py
@@ -5,7 +5,7 @@
 from typing import Dict, List
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox,
-    QFileDialog, QPushButton
+    QFileDialog, QPushButton, QCheckBox
 )
 from PyQt5.QtCore import Qt
 
@@ -39,6 +39,7 @@ class MainWindow(QWidget):
         self.log_area = None
         self.start_button = None
         self.clear_button = None
+        self.save_video_checkbox = None
         self.worker = None
         self.path_button = None
 
@@ -66,6 +67,9 @@ class MainWindow(QWidget):
 
         # 입력 필드 섹션
         self._create_input_section(main_layout)
+
+        # 옵션 섹션
+        self._create_options_section(main_layout)
 
         # 버튼 섹션
         self._create_button_section(main_layout)
@@ -146,6 +150,13 @@ class MainWindow(QWidget):
             # Caps Lock 경고 라벨 (비밀번호 필드)
             if field.caps_lock_label is not None:
                 layout.addWidget(field.caps_lock_label)
+
+    def _create_options_section(self, layout: QVBoxLayout):
+        """옵션 섹션 생성"""
+        self.save_video_checkbox = QCheckBox("📹 원본 동영상을 저장 경로에 보관")
+        self.save_video_checkbox.setStyleSheet(StyleSheet.label())
+        self.save_video_checkbox.setChecked(False)
+        layout.addWidget(self.save_video_checkbox)
 
     def _create_button_section(self, layout: QVBoxLayout):
         """버튼 섹션 생성"""
@@ -276,8 +287,13 @@ class MainWindow(QWidget):
         # 로그 초기화
         self.log_area.clear()
 
+        # 원본 영상 저장 옵션
+        save_video_dir = None
+        if self.save_video_checkbox.isChecked():
+            save_video_dir = ensure_downloads_directory()
+
         # 워커 스레드 시작
-        self.worker = ProcessingWorker(inputs, self.modules)
+        self.worker = ProcessingWorker(inputs, self.modules, save_video_dir=save_video_dir)
         self.worker.log_message.connect(self.log_area.append_message)
         self.worker.processing_finished.connect(self._on_processing_finished)
         self.worker.start()

--- a/src/gui/ui/windows/main_window.py
+++ b/src/gui/ui/windows/main_window.py
@@ -3,6 +3,9 @@
 """
 
 from typing import Dict, List
+import subprocess
+import sys
+
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox,
     QFileDialog, QPushButton, QCheckBox
@@ -42,6 +45,7 @@ class MainWindow(QWidget):
         self.save_video_checkbox = None
         self.worker = None
         self.path_button = None
+        self.path_value_label = None
 
         # 윈도우 설정 및 UI 구성
         self._setup_window()
@@ -104,10 +108,16 @@ class MainWindow(QWidget):
 
         # 현재 경로 표시
         current_path = ensure_downloads_directory()
-        path_value = QLabel(current_path)
-        path_value.setStyleSheet(StyleSheet.path_value())
-        path_value.setWordWrap(True)
-        path_layout.addWidget(path_value, stretch=1)
+        self.path_value_label = QLabel(current_path)
+        self.path_value_label.setStyleSheet(StyleSheet.path_value())
+        self.path_value_label.setWordWrap(True)
+        path_layout.addWidget(self.path_value_label, stretch=1)
+
+        # Finder에서 열기 버튼
+        open_finder_btn = QPushButton("📂 열기")
+        open_finder_btn.setStyleSheet(StyleSheet.button())
+        open_finder_btn.clicked.connect(self._open_in_finder)
+        path_layout.addWidget(open_finder_btn)
 
         # 경로 변경 버튼
         self.path_button = QPushButton("경로 변경")
@@ -130,6 +140,7 @@ class MainWindow(QWidget):
         if new_path:
             try:
                 set_downloads_directory(new_path)
+                self.path_value_label.setText(new_path)
                 self.log_area.append_message(f"✅ 저장 경로가 변경되었습니다: {new_path}")
             except Exception as e:
                 QMessageBox.critical(
@@ -137,6 +148,16 @@ class MainWindow(QWidget):
                     "경로 변경 오류",
                     f"저장 경로 변경 중 오류가 발생했습니다:\n{str(e)}"
                 )
+
+    def _open_in_finder(self):
+        """저장 경로를 Finder(macOS) / 파일 탐색기(Windows)에서 열기"""
+        path = ensure_downloads_directory()
+        if sys.platform == 'darwin':
+            subprocess.Popen(['open', path])
+        elif sys.platform == 'win32':
+            subprocess.Popen(['explorer', path])
+        else:
+            subprocess.Popen(['xdg-open', path])
 
     def _create_input_section(self, layout: QVBoxLayout):
         """입력 필드 섹션 생성"""

--- a/src/gui/ui/windows/main_window.py
+++ b/src/gui/ui/windows/main_window.py
@@ -9,14 +9,14 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt
 
-from src.gui.config.constants import APP_TITLE, APP_VERSION, WINDOW_WIDTH, WINDOW_HEIGHT, Messages
+from src.gui.config.constants import APP_TITLE, APP_VERSION, WINDOW_WIDTH, WINDOW_HEIGHT, Messages, EMOJI_PROCESSING
 from src.gui.config.styles import StyleSheet
 from src.gui.config.settings import INPUT_FIELD_CONFIGS
 from src.gui.core.validators import InputValidator
 from src.gui.core.module_loader import check_required_modules
 from src.gui.core.file_manager import (
     ensure_downloads_directory, set_downloads_directory,
-    get_default_downloads_dir
+    get_default_downloads_dir, save_user_inputs, load_user_inputs
 )
 from src.gui.ui.components.input_field import InputField
 from src.gui.ui.components.log_area import LogArea
@@ -45,6 +45,7 @@ class MainWindow(QWidget):
         # 윈도우 설정 및 UI 구성
         self._setup_window()
         self._setup_ui()
+        self._load_saved_inputs()
         self._check_module_status()
 
     def _setup_window(self):
@@ -91,25 +92,25 @@ class MainWindow(QWidget):
     def _create_path_section(self, layout: QVBoxLayout):
         """저장 경로 설정 섹션 생성"""
         path_layout = QHBoxLayout()
-        
+
         # 라벨
         path_label = QLabel("📁 저장 경로:")
         path_label.setStyleSheet(StyleSheet.label())
         path_layout.addWidget(path_label)
-        
+
         # 현재 경로 표시
         current_path = ensure_downloads_directory()
         path_value = QLabel(current_path)
         path_value.setStyleSheet(StyleSheet.path_value())
         path_value.setWordWrap(True)
         path_layout.addWidget(path_value, stretch=1)
-        
+
         # 경로 변경 버튼
         self.path_button = QPushButton("경로 변경")
         self.path_button.setStyleSheet(StyleSheet.button())
         self.path_button.clicked.connect(self._change_download_path)
         path_layout.addWidget(self.path_button)
-        
+
         layout.addLayout(path_layout)
 
     def _change_download_path(self):
@@ -121,7 +122,7 @@ class MainWindow(QWidget):
             current_path,
             QFileDialog.ShowDirsOnly
         )
-        
+
         if new_path:
             try:
                 set_downloads_directory(new_path)
@@ -142,11 +143,15 @@ class MainWindow(QWidget):
             layout.addWidget(field.label)
             layout.addWidget(field.widget)
 
+            # Caps Lock 경고 라벨 (비밀번호 필드)
+            if field.caps_lock_label is not None:
+                layout.addWidget(field.caps_lock_label)
+
     def _create_button_section(self, layout: QVBoxLayout):
         """버튼 섹션 생성"""
         button_layout = QHBoxLayout()
 
-        # 시작 버튼
+        # 시작/중지 버튼
         self.start_button = ProcessingButton()
         self.start_button.clicked.connect(self._handle_start_processing)
         button_layout.addWidget(self.start_button)
@@ -172,8 +177,19 @@ class MainWindow(QWidget):
                 self.log_area.append_message(f"   - {error}")
             self.log_area.append_message(Messages.INSTALL_REQUIREMENTS)
 
+    def _load_saved_inputs(self):
+        """저장된 입력값 복원"""
+        saved = load_user_inputs()
+        for field_name, value in saved.items():
+            if field_name in self.input_fields and value:
+                self.input_fields[field_name].set_value(value)
+
     def _handle_start_processing(self):
-        """처리 시작 버튼 클릭 핸들러"""
+        """시작/중지 버튼 클릭 핸들러"""
+        if self.start_button.is_processing:
+            self._handle_stop_processing()
+            return
+
         # 입력값 수집
         inputs = self._collect_input_values()
 
@@ -187,6 +203,20 @@ class MainWindow(QWidget):
 
         # 처리 시작
         self._start_background_processing(inputs)
+
+    def _handle_stop_processing(self):
+        """중지 버튼 클릭 핸들러"""
+        reply = QMessageBox.question(
+            self, "확인",
+            "진행 중인 작업을 중지하시겠습니까?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No
+        )
+        if reply == QMessageBox.Yes and self.worker:
+            self.worker.request_cancel()
+            self.log_area.append_message("⚠️ 작업 중지를 요청했습니다. 현재 단계가 끝나면 중지됩니다...")
+            self.start_button.setEnabled(False)
+            self.start_button.setText(f"{EMOJI_PROCESSING} 중지 중...")
 
     def _handle_clear_inputs(self):
         """입력 필드 초기화 버튼 클릭 핸들러"""
@@ -235,6 +265,9 @@ class MainWindow(QWidget):
 
     def _start_background_processing(self, inputs: Dict[str, str]):
         """백그라운드 처리 시작"""
+        # 입력값 저장 (다음 세션을 위해)
+        save_user_inputs(inputs)
+
         # UI 상태 변경
         self.start_button.start_processing()
         self.clear_button.setEnabled(False)
@@ -289,8 +322,11 @@ class MainWindow(QWidget):
             )
 
             if reply == QMessageBox.Yes:
-                self.worker.terminate()
-                self.worker.wait()
+                self.worker.request_cancel()
+                self.worker.wait(5000)
+                if self.worker.isRunning():
+                    self.worker.terminate()
+                    self.worker.wait()
                 event.accept()
             else:
                 event.ignore()

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -2,6 +2,7 @@
 백그라운드에서 LMS 처리 작업을 수행하는 워커 스레드
 """
 
+import threading
 import traceback
 from pathlib import Path
 from typing import Dict, List
@@ -10,6 +11,11 @@ from PyQt5.QtCore import QThread, pyqtSignal
 from src.gui.config.constants import Messages
 from src.gui.core.file_manager import create_config_files, extract_urls_from_input
 from src.gui.core.module_loader import check_required_modules
+
+
+class CancelledException(Exception):
+    """사용자가 작업을 취소했을 때 발생하는 예외"""
+    pass
 
 
 class ProcessingWorker(QThread):
@@ -23,6 +29,20 @@ class ProcessingWorker(QThread):
         super().__init__()
         self.user_inputs = user_inputs
         self.modules = modules
+        self._cancel_event = threading.Event()
+
+    def request_cancel(self):
+        """취소 요청 (메인 스레드에서 호출)"""
+        self._cancel_event.set()
+
+    def is_cancelled(self) -> bool:
+        """취소 요청 여부 확인"""
+        return self._cancel_event.is_set()
+
+    def _check_cancelled(self):
+        """취소 요청 시 CancelledException 발생"""
+        if self._cancel_event.is_set():
+            raise CancelledException("사용자가 작업을 취소했습니다.")
 
     def run(self):
         """실제 처리 작업 실행"""
@@ -33,8 +53,12 @@ class ProcessingWorker(QThread):
             if not self._validate_modules():
                 return
 
+            self._check_cancelled()
+
             # 설정 파일 생성
             self._create_configuration()
+
+            self._check_cancelled()
 
             # 메인 처리 파이프라인 실행
             self._execute_processing_pipeline()
@@ -42,6 +66,10 @@ class ProcessingWorker(QThread):
             # 완료 메시지
             self._emit_log(Messages.PROCESSING_COMPLETE)
             self.processing_finished.emit(True, "작업이 성공적으로 완료되었습니다.")
+
+        except CancelledException:
+            self._emit_log("⚠️ 사용자에 의해 작업이 취소되었습니다.")
+            self.processing_finished.emit(False, "작업이 취소되었습니다.")
 
         except Exception as e:
             error_msg = f"작업 중 오류 발생: {str(e)}"
@@ -82,12 +110,15 @@ class ProcessingWorker(QThread):
         user_setting = self.modules['UserSetting'](self.user_inputs)
 
         # 1. 비디오 다운로드 파이프라인
+        self._check_cancelled()
         video_paths = self._download_videos(urls, user_setting)
 
         # 2. 오디오를 텍스트로 변환
+        self._check_cancelled()
         text_paths = self._convert_audio_to_text(video_paths)
 
         # 3. 텍스트 요약
+        self._check_cancelled()
         self._summarize_texts(text_paths)
 
         # 결과 정리
@@ -101,6 +132,7 @@ class ProcessingWorker(QThread):
         video_pipeline = self.modules['VideoPipeline'](user_setting)
 
         for i, url in enumerate(urls, 1):
+            self._check_cancelled()
             self._emit_log(f"📥 ({i}/{len(urls)}) 다운로드 시작: {url}")
 
         video_paths = video_pipeline.process_sync(urls)
@@ -124,6 +156,7 @@ class ProcessingWorker(QThread):
         text_paths = []
 
         for i, video_path in enumerate(video_paths, 1):
+            self._check_cancelled()
             try:
                 self._emit_log(f"🎤 ({i}/{len(video_paths)}) 텍스트 변환 중: {Path(video_path).name}")
                 self._emit_log(f"📄 원본 파일: {video_path}")
@@ -133,6 +166,8 @@ class ProcessingWorker(QThread):
 
                 self._emit_log(f"{Messages.CONVERSION_COMPLETE}: {text_path}")
 
+            except CancelledException:
+                raise
             except Exception as e:
                 self._emit_log(f"{Messages.CONVERSION_FAILED} ({Path(video_path).name}): {e}")
                 self._emit_log(f"[DEBUG] 오류 상세: {str(e)}")
@@ -153,6 +188,7 @@ class ProcessingWorker(QThread):
         summary_paths = []
 
         for i, text_path in enumerate(text_paths, 1):
+            self._check_cancelled()
             try:
                 self._emit_log(f"📝 ({i}/{len(text_paths)}) 요약 생성 중: {Path(text_path).name}")
                 self._emit_log(f"📄 입력 파일: {text_path}")
@@ -162,6 +198,8 @@ class ProcessingWorker(QThread):
 
                 self._emit_log(f"{Messages.SUMMARY_COMPLETE}: {summary_path}")
 
+            except CancelledException:
+                raise
             except Exception as e:
                 self._emit_log(f"{Messages.SUMMARY_FAILED} ({Path(text_path).name}): {e}")
                 self._emit_log(f"[DEBUG] 오류 상세: {str(e)}")

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -113,6 +113,9 @@ class ProcessingWorker(QThread):
         self._check_cancelled()
         video_paths = self._download_videos(urls, user_setting)
 
+        if not video_paths:
+            raise ValueError(f"다운로드된 영상이 없습니다. ({len(urls)}개 URL 중 0개 성공)")
+
         # 2. 오디오를 텍스트로 변환
         self._check_cancelled()
         text_paths = self._convert_audio_to_text(video_paths)

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -25,10 +25,11 @@ class ProcessingWorker(QThread):
     log_message = pyqtSignal(str)
     processing_finished = pyqtSignal(bool, str)
 
-    def __init__(self, user_inputs: Dict[str, str], modules: Dict):
+    def __init__(self, user_inputs: Dict[str, str], modules: Dict, save_video_dir: str = None):
         super().__init__()
         self.user_inputs = user_inputs
         self.modules = modules
+        self.save_video_dir = save_video_dir
         self._cancel_event = threading.Event()
 
     def request_cancel(self):
@@ -132,11 +133,22 @@ class ProcessingWorker(QThread):
         self._emit_log(f"{Messages.VIDEO_DOWNLOADING}")
         self._emit_log(f"📋 다운로드할 링크: {len(urls)}개")
 
-        video_pipeline = self.modules['VideoPipeline'](user_setting)
+        self._last_progress_pct = -1
+
+        def on_progress(downloaded, total):
+            pct = int(downloaded / total * 100)
+            if pct != self._last_progress_pct and pct % 10 == 0:
+                self._last_progress_pct = pct
+                mb_down = downloaded / (1024 * 1024)
+                mb_total = total / (1024 * 1024)
+                self._emit_log(f"   📊 다운로드 진행: {pct}% ({mb_down:.1f}/{mb_total:.1f} MB)")
+
+        video_pipeline = self.modules['VideoPipeline'](user_setting, progress_callback=on_progress)
 
         for i, url in enumerate(urls, 1):
             self._check_cancelled()
             self._emit_log(f"📥 ({i}/{len(urls)}) 다운로드 시작: {url}")
+            self._last_progress_pct = -1
 
         video_paths = video_pipeline.process_sync(urls)
         self._emit_log(f"{Messages.DOWNLOAD_COMPLETE}: {len(video_paths)}개 파일")
@@ -146,7 +158,38 @@ class ProcessingWorker(QThread):
         for i, filepath in enumerate(video_paths, 1):
             self._emit_log(f"   📹 ({i}) {filepath}")
 
+        # 원본 영상 저장 옵션
+        if self.save_video_dir and video_paths:
+            self._save_videos_to_dir(video_paths)
+
         return video_paths
+
+    def _save_videos_to_dir(self, video_paths: List[str]):
+        """원본 영상을 사용자 지정 경로에 저장"""
+        import shutil
+        self._emit_log(f"📂 원본 영상 저장 경로: {self.save_video_dir}")
+
+        for filepath in video_paths:
+            src = Path(filepath)
+            dest = Path(self.save_video_dir) / src.name
+
+            # 이미 같은 경로면 스킵
+            if src.resolve() == dest.resolve():
+                self._emit_log(f"   ✅ 이미 저장 경로에 있음: {src.name}")
+                continue
+
+            # 파일명 충돌 시 자동 번호 추가
+            if dest.exists():
+                stem = src.stem
+                suffix = src.suffix
+                counter = 1
+                while dest.exists():
+                    dest = Path(self.save_video_dir) / f"{stem}_{counter}{suffix}"
+                    counter += 1
+                self._emit_log(f"   ⚠️ 파일명 충돌로 이름 변경: {dest.name}")
+
+            shutil.copy2(str(src), str(dest))
+            self._emit_log(f"   📹 저장 완료: {dest}")
 
     def _convert_audio_to_text(self, video_paths: List[str]) -> List[str]:
         """오디오를 텍스트로 변환"""
@@ -156,6 +199,7 @@ class ProcessingWorker(QThread):
         self._check_ffmpeg()
 
         audio_pipeline = self.modules['AudioToTextPipeline']()
+        audio_pipeline.downloads_dir = str(Path(video_paths[0]).parent)
         text_paths = []
 
         for i, video_path in enumerate(video_paths, 1):
@@ -188,6 +232,8 @@ class ProcessingWorker(QThread):
         self._emit_log(Messages.TEXT_SUMMARIZING)
 
         summarize_pipeline = self.modules['SummarizePipeline']()
+        if text_paths:
+            summarize_pipeline.downloads_dir = str(Path(text_paths[0]).parent)
         summary_paths = []
 
         for i, text_path in enumerate(text_paths, 1):

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 from PyQt5.QtCore import QThread, pyqtSignal
 
 from src.gui.config.constants import Messages
-from src.gui.core.file_manager import create_config_files, extract_urls_from_input
+from src.gui.core.file_manager import create_config_files, extract_urls_from_input, ensure_downloads_directory
 from src.gui.core.module_loader import check_required_modules
 
 
@@ -144,6 +144,7 @@ class ProcessingWorker(QThread):
                 self._emit_log(f"   📊 다운로드 진행: {pct}% ({mb_down:.1f}/{mb_total:.1f} MB)")
 
         video_pipeline = self.modules['VideoPipeline'](user_setting, progress_callback=on_progress)
+        video_pipeline.downloads_dir = ensure_downloads_directory()
 
         for i, url in enumerate(urls, 1):
             self._check_cancelled()
@@ -199,12 +200,13 @@ class ProcessingWorker(QThread):
         self._check_ffmpeg()
 
         audio_pipeline = self.modules['AudioToTextPipeline']()
-        audio_pipeline.downloads_dir = str(Path(video_paths[0]).parent)
         text_paths = []
 
         for i, video_path in enumerate(video_paths, 1):
             self._check_cancelled()
             try:
+                # 각 비디오 파일의 디렉토리에 텍스트 저장
+                audio_pipeline.downloads_dir = str(Path(video_path).parent)
                 self._emit_log(f"🎤 ({i}/{len(video_paths)}) 텍스트 변환 중: {Path(video_path).name}")
                 self._emit_log(f"📄 원본 파일: {video_path}")
 
@@ -232,13 +234,13 @@ class ProcessingWorker(QThread):
         self._emit_log(Messages.TEXT_SUMMARIZING)
 
         summarize_pipeline = self.modules['SummarizePipeline']()
-        if text_paths:
-            summarize_pipeline.downloads_dir = str(Path(text_paths[0]).parent)
         summary_paths = []
 
         for i, text_path in enumerate(text_paths, 1):
             self._check_cancelled()
             try:
+                # 각 텍스트 파일의 디렉토리에 요약 저장
+                summarize_pipeline.downloads_dir = str(Path(text_path).parent)
                 self._emit_log(f"📝 ({i}/{len(text_paths)}) 요약 생성 중: {Path(text_path).name}")
                 self._emit_log(f"📄 입력 파일: {text_path}")
 
@@ -301,9 +303,7 @@ class ProcessingWorker(QThread):
 
         # 저장 위치 안내
         if video_paths or text_paths:
-            from src.gui.core.file_manager import get_resource_path
-            downloads_dir = get_resource_path("downloads")
+            downloads_dir = ensure_downloads_directory()
             self._emit_log(f"\n📁 모든 파일이 저장된 위치: {downloads_dir}")
-            self._emit_log("💡 Finder에서 확인: open downloads/")
 
         self._emit_log("="*50)

--- a/src/summarize_pipeline/summarizer.py
+++ b/src/summarize_pipeline/summarizer.py
@@ -87,11 +87,6 @@ class GeminiSummarizer(Summarizer):
 
         print(f"[DEBUG] 텍스트 길이: {len(content)}자")
 
-        # 텍스트가 너무 길면 자르기 (Gemini 토큰 제한 고려)
-        if len(content) > 8000:
-            print(f"[WARNING] 텍스트가 너무 깁니다 ({len(content)}자). 8000자로 제한합니다.")
-            content = content[:8000] + "..."
-
         full_prompt = f"{prompt}\n\n다음은 전체 텍스트입니다:\n{content}"
 
         print("[DEBUG] Google Gemini API 호출 시작...")

--- a/src/video_pipeline/download_video.py
+++ b/src/video_pipeline/download_video.py
@@ -2,10 +2,16 @@ import os
 import random
 import string
 import requests
+from typing import Callable, Optional
 from src.gui.core.file_manager import get_downloads_dir
 
 
-def download_video(url: str, filename: str = None, save_dir: str = None) -> str:
+def download_video(
+    url: str,
+    filename: str = None,
+    save_dir: str = None,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+) -> str:
     if filename is None:
         # 랜덤 알파벳 8자리
         filename = ''.join(random.choices(
@@ -25,10 +31,16 @@ def download_video(url: str, filename: str = None, save_dir: str = None) -> str:
         response = requests.get(url, stream=True)
         response.raise_for_status()
 
+        total_size = int(response.headers.get('content-length', 0))
+        downloaded = 0
+
         with open(filepath, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 if chunk:
                     f.write(chunk)
+                    downloaded += len(chunk)
+                    if progress_callback and total_size > 0:
+                        progress_callback(downloaded, total_size)
 
         print(f"[SUCCESS] 다운로드 완료: {filepath}")
         return os.path.abspath(filepath)

--- a/src/video_pipeline/download_video.py
+++ b/src/video_pipeline/download_video.py
@@ -5,7 +5,7 @@ import requests
 from src.gui.core.file_manager import get_downloads_dir
 
 
-def download_video(url: str, filename: str = None) -> str:
+def download_video(url: str, filename: str = None, save_dir: str = None) -> str:
     if filename is None:
         # 랜덤 알파벳 8자리
         filename = ''.join(random.choices(
@@ -16,7 +16,9 @@ def download_video(url: str, filename: str = None) -> str:
         filename += '.mp4'
 
     try:
-        save_dir = get_downloads_dir()
+        if save_dir is None:
+            save_dir = get_downloads_dir()
+        os.makedirs(save_dir, exist_ok=True)
         filepath = os.path.join(save_dir, filename)
 
         print(f"[INFO] 동영상 다운로드 중...: {url}")

--- a/src/video_pipeline/pipeline.py
+++ b/src/video_pipeline/pipeline.py
@@ -9,11 +9,12 @@ from src.user_setting import UserSetting
 
 
 class VideoPipeline:
-    def __init__(self, user_setting: UserSetting):
+    def __init__(self, user_setting: UserSetting, extraction_timeout: float = 60):
         self.user_setting = user_setting
         self.user_id = user_setting.user_id
         self.password = user_setting.password
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
+        self.extraction_timeout = extraction_timeout
 
     async def _setup_browser(self, playwright: Playwright) -> Tuple[Page, any]:
         """브라우저 설정 및 페이지 생성"""
@@ -59,7 +60,7 @@ class VideoPipeline:
         else:
             print("[INFO] 로그인 불필요.")
 
-        video_url, title = await extract_video_url(page)
+        video_url, title = await extract_video_url(page, method="dom", timeout=self.extraction_timeout)
 
         if video_url:
             print(f"[SUCCESS] 동영상 링크 추출됨: {video_url}, 제목: {title}")

--- a/src/video_pipeline/pipeline.py
+++ b/src/video_pipeline/pipeline.py
@@ -1,4 +1,6 @@
 import asyncio
+import re
+from pathlib import Path
 from playwright.async_api import async_playwright, Playwright, Page
 from typing import Callable, Optional, Tuple
 
@@ -6,6 +8,14 @@ from src.video_pipeline.login import perform_login_if_needed
 from src.video_pipeline.video_parser import extract_video_url
 from src.video_pipeline.download_video import download_video
 from src.user_setting import UserSetting
+
+
+def sanitize_dirname(name: str) -> str:
+    """디렉토리명에 사용할 수 없는 문자 제거"""
+    sanitized = re.sub(r'[<>:"/\\|?*]', '', name)
+    sanitized = sanitized.strip(' .')
+    sanitized = re.sub(r'\s+', ' ', sanitized)
+    return sanitized or 'untitled'
 
 
 class VideoPipeline:
@@ -66,7 +76,16 @@ class VideoPipeline:
 
         if video_url:
             print(f"[SUCCESS] 동영상 링크 추출됨: {video_url}, 제목: {title}")
-            filepath = download_video(video_url, save_dir=self.downloads_dir, filename=title,
+
+            # 강의 이름으로 하위 디렉토리 생성
+            save_dir = self.downloads_dir
+            if title and save_dir:
+                lecture_dir = Path(save_dir) / sanitize_dirname(title)
+                lecture_dir.mkdir(parents=True, exist_ok=True)
+                save_dir = str(lecture_dir)
+                print(f"[INFO] 강의 폴더: {save_dir}")
+
+            filepath = download_video(video_url, save_dir=save_dir, filename=title,
                                      progress_callback=self.progress_callback)
             print(f"[SUCCESS] 동영상 다운로드 완료: {filepath}")
             return filepath

--- a/src/video_pipeline/pipeline.py
+++ b/src/video_pipeline/pipeline.py
@@ -1,6 +1,6 @@
 import asyncio
 from playwright.async_api import async_playwright, Playwright, Page
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 from src.video_pipeline.login import perform_login_if_needed
 from src.video_pipeline.video_parser import extract_video_url
@@ -9,12 +9,14 @@ from src.user_setting import UserSetting
 
 
 class VideoPipeline:
-    def __init__(self, user_setting: UserSetting, extraction_timeout: float = 60):
+    def __init__(self, user_setting: UserSetting, extraction_timeout: float = 60,
+                 progress_callback: Optional[Callable[[int, int], None]] = None):
         self.user_setting = user_setting
         self.user_id = user_setting.user_id
         self.password = user_setting.password
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
         self.extraction_timeout = extraction_timeout
+        self.progress_callback = progress_callback
 
     async def _setup_browser(self, playwright: Playwright) -> Tuple[Page, any]:
         """브라우저 설정 및 페이지 생성"""
@@ -64,7 +66,8 @@ class VideoPipeline:
 
         if video_url:
             print(f"[SUCCESS] 동영상 링크 추출됨: {video_url}, 제목: {title}")
-            filepath = download_video(video_url, save_dir=self.downloads_dir, filename=title)
+            filepath = download_video(video_url, save_dir=self.downloads_dir, filename=title,
+                                     progress_callback=self.progress_callback)
             print(f"[SUCCESS] 동영상 다운로드 완료: {filepath}")
             return filepath
         else:

--- a/src/video_pipeline/video_parser.py
+++ b/src/video_pipeline/video_parser.py
@@ -34,36 +34,42 @@ async def find_canvas_video_frame(page: Page, shared_state: dict):
     return None
 
 
-async def trigger_video_play(frame, resume: bool = True):
-    """재생 버튼을 클릭하고 이어보기 다이얼로그를 처리한다.
-
-    Args:
-        frame: 비디오 컨트롤이 있는 inner iframe.
-        resume: True면 "예"(.confirm-ok-btn) 클릭, False면 "아니오"(.confirm-cancel-btn) 클릭.
-    """
+async def trigger_video_play(frame):
+    """재생 버튼을 클릭한다."""
     try:
         play_btn = await frame.wait_for_selector(".vc-front-screen-play-btn", timeout=5000)
         await play_btn.click()
         print("[INFO] 재생 버튼 클릭됨.")
     except Exception:
         print("[WARN] 재생 버튼을 찾을 수 없음.")
-        return
 
+
+async def try_dismiss_confirm_dialog(frame, resume: bool = True) -> bool:
+    """이어보기 다이얼로그가 보이면 클릭한다. 클릭했으면 True.
+
+    매 폴링마다 호출되므로 query_selector(비대기)를 사용한다.
+    """
     try:
-        confirm_dialog = await frame.wait_for_selector(".confirm-msg-box", timeout=5000)
-        if confirm_dialog:
-            if resume:
-                ok_btn = await frame.wait_for_selector(".confirm-ok-btn.confirm-btn", timeout=2000)
-                if ok_btn:
-                    await ok_btn.click()
-                    print("[INFO] 이어보기(예) 클릭됨.")
-            else:
-                cancel_btn = await frame.wait_for_selector(".confirm-cancel-btn.confirm-btn", timeout=2000)
-                if cancel_btn:
-                    await cancel_btn.click()
-                    print("[INFO] 처음부터(아니오) 클릭됨.")
-    except Exception:
-        pass  # 다이얼로그가 나타나지 않은 경우 (처음 재생)
+        dialog = await frame.query_selector(".confirm-msg-box")
+        if not dialog:
+            return False
+        if not await dialog.is_visible():
+            return False
+
+        if resume:
+            btn = await frame.query_selector(".confirm-ok-btn")
+        else:
+            btn = await frame.query_selector(".confirm-cancel-btn")
+
+        if btn:
+            await btn.click()
+            label = "이어보기(예)" if resume else "처음부터(아니오)"
+            print(f"[INFO] {label} 클릭됨.")
+            return True
+    except Exception as e:
+        print(f"[DEBUG] 다이얼로그 처리 중 오류: {e}")
+
+    return False
 
 
 # ==============================================================
@@ -100,13 +106,18 @@ class DomVideoExtractor(VideoUrlExtractor):
         if not video_frame:
             return None, None
 
-        await trigger_video_play(video_frame, resume=True)
+        await trigger_video_play(video_frame)
 
         print("[DEBUG] DOM에서 비디오 URL 대기 시작")
         poll_interval = 0.5
         max_polls = int(timeout / poll_interval)
+        dialog_dismissed = False
 
         for _ in range(max_polls):
+            # 매 폴링마다 이어보기 다이얼로그 체크
+            if not dialog_dismissed:
+                dialog_dismissed = await try_dismiss_confirm_dialog(video_frame, resume=True)
+
             try:
                 video_el = await video_frame.query_selector(self.VIDEO_SELECTOR)
                 if video_el:
@@ -166,7 +177,8 @@ class CdpVideoExtractor(VideoUrlExtractor):
         if not video_frame:
             return None, None
 
-        await trigger_video_play(video_frame, resume=False)
+        await trigger_video_play(video_frame)
+        await try_dismiss_confirm_dialog(video_frame, resume=False)
 
         print("[DEBUG] CDP 비디오 URL 대기 시작")
         poll_interval = 0.1

--- a/src/video_pipeline/video_parser.py
+++ b/src/video_pipeline/video_parser.py
@@ -1,23 +1,19 @@
 import asyncio
+from abc import ABC, abstractmethod
 from playwright.sync_api import Page
 
 
-async def on_request(event, shared_state: dict):
-    url = event["request"]["url"]
-    print(f"[CDP] 요청 감지: {url}")
-    if "ssmovie.mp4" in url and shared_state["video_url"] is None:
-        print(f"[CDP] ssmovie.mp4 요청 감지: {url}")
-        shared_state["video_url"] = url
-
-
-async def register_cdp_video_sniffer(page: Page, shared_state: dict):
-    client = await page.context.new_cdp_session(page)
-    await client.send("Network.enable")
-    client.on("Network.requestWillBeSent",
-              lambda e: asyncio.create_task(on_request(e, shared_state)))
-
+# ==============================================================
+# 공통 헬퍼
+# ==============================================================
 
 async def find_canvas_video_frame(page: Page, shared_state: dict):
+    """LMS 페이지의 중첩 iframe 구조에서 비디오 플레이어가 있는 inner iframe을 찾는다.
+
+    iframe 구조:
+    1. outer iframe (name="tool_content")
+    2. inner iframe (class="xnlailvc-commons-frame", src에 "commons.ssu.ac.kr" 포함)
+    """
     for _ in range(10):
         outer = page.frame(name="tool_content")
         if outer:
@@ -27,7 +23,7 @@ async def find_canvas_video_frame(page: Page, shared_state: dict):
                 if title_element:
                     shared_state["title"] = await title_element.text_content()
                     print(f"[DEBUG] 제목 찾음: {shared_state['title']}")
-            except:
+            except Exception:
                 print("[WARN] 제목을 찾을 수 없음")
             for frame in page.frames:
                 if frame.parent_frame == outer and "commons.ssu.ac.kr" in frame.url:
@@ -38,41 +34,184 @@ async def find_canvas_video_frame(page: Page, shared_state: dict):
     return None
 
 
-async def trigger_video_play(frame):
+async def trigger_video_play(frame, resume: bool = True):
+    """재생 버튼을 클릭하고 이어보기 다이얼로그를 처리한다.
+
+    Args:
+        frame: 비디오 컨트롤이 있는 inner iframe.
+        resume: True면 "예"(.confirm-ok-btn) 클릭, False면 "아니오"(.confirm-cancel-btn) 클릭.
+    """
     try:
         play_btn = await frame.wait_for_selector(".vc-front-screen-play-btn", timeout=5000)
         await play_btn.click()
         print("[INFO] 재생 버튼 클릭됨.")
-    except:
+    except Exception:
         print("[WARN] 재생 버튼을 찾을 수 없음.")
         return
 
     try:
         confirm_dialog = await frame.wait_for_selector("#confirm-dialog", timeout=2000)
-        cancel_btn = await confirm_dialog.query_selector(".confirm-cancel-btn.confirm-btn")
-        if cancel_btn:
-            await cancel_btn.click()
-            print("[INFO] 확인창 닫음.")
-    except:
+        if resume:
+            ok_btn = await confirm_dialog.query_selector(".confirm-ok-btn")
+            if ok_btn:
+                await ok_btn.click()
+                print("[INFO] 이어보기(예) 클릭됨.")
+        else:
+            cancel_btn = await confirm_dialog.query_selector(".confirm-cancel-btn.confirm-btn")
+            if cancel_btn:
+                await cancel_btn.click()
+                print("[INFO] 처음부터(아니오) 클릭됨.")
+    except Exception:
+        pass  # 다이얼로그가 나타나지 않은 경우 (처음 재생)
+
+
+# ==============================================================
+# 추상 베이스 클래스
+# ==============================================================
+
+class VideoUrlExtractor(ABC):
+    """비디오 URL 추출 전략의 베이스 클래스."""
+
+    @abstractmethod
+    async def extract(self, page: Page, timeout: float = 60) -> tuple[str, str]:
+        """페이지에서 비디오 URL과 제목을 추출한다.
+
+        Returns:
+            (video_url, title) 튜플. 실패 시 (None, None).
+        """
         pass
 
 
-async def extract_video_url(page: Page) -> tuple[str, str]:
-    shared_state = {"video_url": None, "title": None}
-    await register_cdp_video_sniffer(page, shared_state)
+# ==============================================================
+# DOM 기반 추출 (기본 방식)
+# ==============================================================
 
-    video_frame = await find_canvas_video_frame(page, shared_state)
-    if not video_frame:
+class DomVideoExtractor(VideoUrlExtractor):
+    """재생 후 video.vc-vplay-video1 요소의 src 속성에서 URL을 추출한다."""
+
+    VIDEO_SELECTOR = "video.vc-vplay-video1"
+    VIDEO_URL_PATTERN = ".mp4"
+
+    async def extract(self, page: Page, timeout: float = 60) -> tuple[str, str]:
+        shared_state = {"video_url": None, "title": None}
+
+        video_frame = await find_canvas_video_frame(page, shared_state)
+        if not video_frame:
+            return None, None
+
+        await trigger_video_play(video_frame, resume=True)
+
+        print("[DEBUG] DOM에서 비디오 URL 대기 시작")
+        poll_interval = 0.5
+        max_polls = int(timeout / poll_interval)
+
+        for _ in range(max_polls):
+            try:
+                video_el = await video_frame.query_selector(self.VIDEO_SELECTOR)
+                if video_el:
+                    src = await video_el.get_attribute("src")
+                    if src and self.VIDEO_URL_PATTERN in src:
+                        print(f"[DEBUG] DOM에서 비디오 URL 찾음: {src}")
+                        shared_state["video_url"] = src
+                        return src, shared_state["title"]
+            except Exception as e:
+                print(f"[WARN] DOM 폴링 중 오류: {e}")
+
+            await asyncio.sleep(poll_interval)
+
+        print("[DEBUG] DOM에서 비디오 URL을 찾지 못했습니다.")
         return None, None
 
-    await trigger_video_play(video_frame)
 
-    print("[DEBUG] 비디오 URL 대기 시작")
-    for _ in range(100):  # 최대 10초 대기 (0.1초 간격)
-        if shared_state["video_url"]:
-            print(f"[DEBUG] 비디오 URL 찾음: {shared_state['video_url']}")
-            return shared_state["video_url"], shared_state["title"]
-        await asyncio.sleep(0.1)
+# ==============================================================
+# CDP 기반 추출 (deprecated fallback)
+# ==============================================================
 
-    print("[DEBUG] 비디오 URL을 찾지 못했습니다.")
-    return None, None
+class CdpVideoExtractor(VideoUrlExtractor):
+    """CDP Network.requestWillBeSent로 ssmovie.mp4 요청을 가로채서 URL을 추출한다.
+
+    DEPRECATED: CDP 스니핑이 더 이상 안정적으로 동작하지 않는다.
+    DomVideoExtractor가 실패할 경우의 fallback으로 유지한다.
+    """
+
+    VIDEO_URL_PATTERN = "ssmovie.mp4"
+
+    async def _on_request(self, event, shared_state: dict):
+        url = event["request"]["url"]
+        if self.VIDEO_URL_PATTERN in url and shared_state["video_url"] is None:
+            print(f"[CDP] ssmovie.mp4 요청 감지: {url}")
+            shared_state["video_url"] = url
+
+    async def _register_sniffer(self, page: Page, shared_state: dict):
+        client = await page.context.new_cdp_session(page)
+        await client.send("Network.enable")
+        client.on(
+            "Network.requestWillBeSent",
+            lambda e: asyncio.create_task(self._on_request(e, shared_state)),
+        )
+
+    async def extract(self, page: Page, timeout: float = 60) -> tuple[str, str]:
+        import warnings
+        warnings.warn(
+            "CdpVideoExtractor is deprecated. Use DomVideoExtractor instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        shared_state = {"video_url": None, "title": None}
+        await self._register_sniffer(page, shared_state)
+
+        video_frame = await find_canvas_video_frame(page, shared_state)
+        if not video_frame:
+            return None, None
+
+        await trigger_video_play(video_frame, resume=False)
+
+        print("[DEBUG] CDP 비디오 URL 대기 시작")
+        poll_interval = 0.1
+        max_polls = int(timeout / poll_interval)
+
+        for _ in range(max_polls):
+            if shared_state["video_url"]:
+                print(f"[DEBUG] CDP 비디오 URL 찾음: {shared_state['video_url']}")
+                return shared_state["video_url"], shared_state["title"]
+            await asyncio.sleep(poll_interval)
+
+        print("[DEBUG] CDP 비디오 URL을 찾지 못했습니다.")
+        return None, None
+
+
+# ==============================================================
+# 팩토리 함수 (진입점)
+# ==============================================================
+
+_EXTRACTORS = {
+    "dom": DomVideoExtractor,
+    "cdp": CdpVideoExtractor,
+}
+
+
+async def extract_video_url(
+    page: Page,
+    method: str = "dom",
+    timeout: float = 60,
+) -> tuple[str, str]:
+    """LMS 페이지에서 비디오 URL을 추출한다.
+
+    Args:
+        page: LMS 콘텐츠가 로드된 Playwright 페이지.
+        method: "dom" (기본, 권장) 또는 "cdp" (deprecated fallback).
+        timeout: 최대 대기 시간(초). 기본 60초.
+
+    Returns:
+        (video_url, title) 튜플. 실패 시 (None, None).
+    """
+    extractor_cls = _EXTRACTORS.get(method)
+    if extractor_cls is None:
+        raise ValueError(
+            f"Unknown extraction method '{method}'. "
+            f"Supported: {list(_EXTRACTORS.keys())}"
+        )
+
+    extractor = extractor_cls()
+    return await extractor.extract(page, timeout=timeout)

--- a/src/video_pipeline/video_parser.py
+++ b/src/video_pipeline/video_parser.py
@@ -110,7 +110,7 @@ class DomVideoExtractor(VideoUrlExtractor):
                 video_el = await video_frame.query_selector(self.VIDEO_SELECTOR)
                 if video_el:
                     src = await video_el.get_attribute("src")
-                    if src and self.VIDEO_URL_PATTERN in src:
+                    if src and src.startswith("http") and self.VIDEO_URL_PATTERN in src:
                         print(f"[DEBUG] DOM에서 비디오 URL 찾음: {src}")
                         shared_state["video_url"] = src
                         return src, shared_state["title"]

--- a/src/video_pipeline/video_parser.py
+++ b/src/video_pipeline/video_parser.py
@@ -50,17 +50,18 @@ async def trigger_video_play(frame, resume: bool = True):
         return
 
     try:
-        confirm_dialog = await frame.wait_for_selector("#confirm-dialog", timeout=2000)
-        if resume:
-            ok_btn = await confirm_dialog.query_selector(".confirm-ok-btn")
-            if ok_btn:
-                await ok_btn.click()
-                print("[INFO] 이어보기(예) 클릭됨.")
-        else:
-            cancel_btn = await confirm_dialog.query_selector(".confirm-cancel-btn.confirm-btn")
-            if cancel_btn:
-                await cancel_btn.click()
-                print("[INFO] 처음부터(아니오) 클릭됨.")
+        confirm_dialog = await frame.wait_for_selector(".confirm-msg-box", timeout=5000)
+        if confirm_dialog:
+            if resume:
+                ok_btn = await frame.wait_for_selector(".confirm-ok-btn.confirm-btn", timeout=2000)
+                if ok_btn:
+                    await ok_btn.click()
+                    print("[INFO] 이어보기(예) 클릭됨.")
+            else:
+                cancel_btn = await frame.wait_for_selector(".confirm-cancel-btn.confirm-btn", timeout=2000)
+                if cancel_btn:
+                    await cancel_btn.click()
+                    print("[INFO] 처음부터(아니오) 클릭됨.")
     except Exception:
         pass  # 다이얼로그가 나타나지 않은 경우 (처음 재생)
 


### PR DESCRIPTION
## Summary
- DOM 기반 비디오 URL 추출로 전환 (CDP → DOM)하여 안정성 향상
- GUI 사용성 개선: 비밀번호 토글, 입력값 저장, 중지 버튼, Ctrl+C 지원
- 파일 저장 경로를 사용자 설정 경로로 통합하고 강의명 폴더 자동 생성
- Gemini 요약 8000자 제한 제거, Finder 열기 버튼 추가

## 주요 변경사항

### 비디오 다운로드
- CDP 스니핑 → DOM 기반 `video.vc-vplay-video1` src 추출로 전환
- 이어보기 다이얼로그(`.confirm-msg-box`) 폴링 루프 내 지속 감지
- 인트로 영상 상대경로 URL 필터링 (`src.startswith("http")` 체크)
- 다운로드 진행도 콜백 지원

### GUI 개선
- 비밀번호 show/hide 토글 (QPushButton 오버레이) + Caps Lock 경고
- 학번/API 키/URL 입력값 자동 저장 및 복원 (비밀번호 제외)
- 처리 중 시작 버튼 → 빨간 중지 버튼 변환 (threading.Event 기반 취소)
- `signal.signal(SIGINT, SIG_DFL)`로 Ctrl+C 즉시 종료 지원

### 파일 경로
- 모든 출력 파일(영상/텍스트/요약)이 사용자 설정 경로에 저장
- 강의 이름(xnlailct-title) 기반 하위 폴더 자동 생성
- "📂 열기" 버튼으로 Finder/Explorer에서 저장 경로 열기
- 원본 영상 보관 체크박스 옵션

### 요약
- Gemini 8000자 텍스트 길이 제한 제거 (Gemini 1.5 Flash 1M 토큰 활용)

## Test plan
- [x] GUI 실행 후 비밀번호 👁 토글 및 Caps Lock 경고 확인
- [x] 앱 재시작 시 이전 입력값 자동 로드 확인 (비밀번호 제외)
- [x] 처리 중 중지 버튼 동작 확인
- [x] 터미널 Ctrl+C로 앱 즉시 종료 확인
- [x] 다운로드된 파일이 사용자 설정 경로/강의명 폴더에 저장되는지 확인
- [x] "📂 열기" 버튼으로 Finder 열리는지 확인
- [x] 긴 텍스트(8000자 이상) 요약이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)