### PR TITLE
refactor: 코드 정리 및 다운로드 안정성 개선

### DIFF
--- a/src/audio_pipeline/pipeline.py
+++ b/src/audio_pipeline/pipeline.py
@@ -1,8 +1,9 @@
+import os
 import time
+from pathlib import Path
+
 from src.audio_pipeline.converter import convert_mp4_to_wav
 from src.audio_pipeline.transcriber import transcribe_wav_to_text
-import os
-from pathlib import Path
 
 
 class AudioToTextPipeline:

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -146,11 +146,7 @@ class ProcessingWorker(QThread):
         video_pipeline = self.modules['VideoPipeline'](user_setting, progress_callback=on_progress)
         video_pipeline.downloads_dir = ensure_downloads_directory()
 
-        for i, url in enumerate(urls, 1):
-            self._check_cancelled()
-            self._emit_log(f"📥 ({i}/{len(urls)}) 다운로드 시작: {url}")
-            self._last_progress_pct = -1
-
+        self._check_cancelled()
         video_paths = video_pipeline.process_sync(urls)
         self._emit_log(f"{Messages.DOWNLOAD_COMPLETE}: {len(video_paths)}개 파일")
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,7 @@
+"""
+DEPRECATED: CLI 진입점. GUI(src/gui/main.py)로 대체 예정.
+개발/디버깅 목적으로만 사용할 것.
+"""
 from audio_pipeline.pipeline import AudioToTextPipeline
 from summarize_pipeline.pipeline import SummarizePipeline
 from user_setting import UserSetting

--- a/src/summarize_pipeline/pipeline.py
+++ b/src/summarize_pipeline/pipeline.py
@@ -1,8 +1,8 @@
-import time
-import sys
 import os
-from src.summarize_pipeline.summarizer import summarize_text
+import time
 from pathlib import Path
+
+from src.summarize_pipeline.summarizer import summarize_text
 
 
 class SummarizePipeline:

--- a/src/summarize_pipeline/summarizer.py
+++ b/src/summarize_pipeline/summarizer.py
@@ -3,16 +3,8 @@ import google.generativeai as genai
 import webbrowser
 from openai import OpenAI
 import pyperclip
-import sys
-import os
 
 from src.user_setting import UserSetting
-
-
-# def resource_path(relative_path):
-#     if hasattr(sys, '_MEIPASS'):
-#         return os.path.join(sys._MEIPASS, relative_path)
-#     return os.path.join(os.path.abspath("."), relative_path)
 
 
 def summarize_text(txt_path: str, prompt: str, engine: str = "gemini"):

--- a/src/user_setting.py
+++ b/src/user_setting.py
@@ -19,12 +19,14 @@ class UserSetting:
             self.RETURNZERO_CLIENT_ID = os.getenv("RETURNZERO_CLIENT_ID")
             self.RETURNZERO_CLIENT_SECRET = os.getenv("RETURNZERO_CLIENT_SECRET")
             self.GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+            self.OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
         else:
             self.user_id = self.gui_inputs.get('student_id')
             self.password = self.gui_inputs.get('password')
             self.RETURNZERO_CLIENT_ID = self.gui_inputs.get('returnzero_client_id')
             self.RETURNZERO_CLIENT_SECRET = self.gui_inputs.get('returnzero_client_secret')
             self.GOOGLE_API_KEY = self.gui_inputs.get('api_key')
+            self.OPENAI_API_KEY = self.gui_inputs.get('openai_api_key')
 
     def get_video_urls(self) -> list[str]:
         # GUI 입력값이 있으면 사용

--- a/src/video_pipeline/download_video.py
+++ b/src/video_pipeline/download_video.py
@@ -1,9 +1,17 @@
 import os
 import random
 import string
-import requests
+import time
+from http.client import IncompleteRead
 from typing import Callable, Optional
+
+import requests
+
 from src.gui.core.file_manager import get_downloads_dir
+
+_MAX_RETRIES = 3
+_TIMEOUT = (10, 60)  # (connect timeout, read timeout) in seconds
+_CHUNK_SIZE = 65536   # 64KB chunks (더 빠른 대용량 파일 다운로드)
 
 
 def download_video(
@@ -13,37 +21,68 @@ def download_video(
     progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> str:
     if filename is None:
-        # 랜덤 알파벳 8자리
-        filename = ''.join(random.choices(
-            string.ascii_letters + string.digits, k=8))
+        filename = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
 
-    # 파일 확장자 추가
     if not filename.endswith('.mp4'):
         filename += '.mp4'
 
-    try:
-        if save_dir is None:
-            save_dir = get_downloads_dir()
-        os.makedirs(save_dir, exist_ok=True)
-        filepath = os.path.join(save_dir, filename)
+    if save_dir is None:
+        save_dir = get_downloads_dir()
+    os.makedirs(save_dir, exist_ok=True)
+    filepath = os.path.join(save_dir, filename)
 
-        print(f"[INFO] 동영상 다운로드 중...: {url}")
-        response = requests.get(url, stream=True)
-        response.raise_for_status()
+    last_error = None
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            _download_with_progress(url, filepath, progress_callback, attempt)
+            print(f"[SUCCESS] 다운로드 완료: {filepath}")
+            return os.path.abspath(filepath)
 
-        total_size = int(response.headers.get('content-length', 0))
-        downloaded = 0
+        except (IncompleteRead, requests.exceptions.ChunkedEncodingError) as e:
+            last_error = e
+            _remove_partial_file(filepath)
+            if attempt < _MAX_RETRIES:
+                wait = 2 ** attempt  # 2, 4, 8초 지수 백오프
+                print(f"[WARN] 연결 끊김, {wait}초 후 재시도 ({attempt}/{_MAX_RETRIES}): {e}")
+                time.sleep(wait)
+            else:
+                print(f"[ERROR] {_MAX_RETRIES}회 재시도 후 다운로드 실패: {e}")
 
-        with open(filepath, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-                    downloaded += len(chunk)
-                    if progress_callback and total_size > 0:
-                        progress_callback(downloaded, total_size)
+        except Exception as e:
+            last_error = e
+            _remove_partial_file(filepath)
+            print(f"[ERROR] 다운로드 실패: {e}")
+            break  # 네트워크 끊김이 아닌 오류는 재시도 안 함
 
-        print(f"[SUCCESS] 다운로드 완료: {filepath}")
-        return os.path.abspath(filepath)
-    except Exception as e:
-        print(f"[ERROR] 다운로드 실패: {e}")
-        raise e
+    raise last_error
+
+
+def _download_with_progress(
+    url: str,
+    filepath: str,
+    progress_callback: Optional[Callable[[int, int], None]],
+    attempt: int,
+):
+    print(f"[INFO] 동영상 다운로드 중... (시도 {attempt}/{_MAX_RETRIES}): {url}")
+    response = requests.get(url, stream=True, timeout=_TIMEOUT)
+    response.raise_for_status()
+
+    total_size = int(response.headers.get('content-length', 0))
+    downloaded = 0
+
+    with open(filepath, "wb") as f:
+        for chunk in response.iter_content(chunk_size=_CHUNK_SIZE):
+            if chunk:
+                f.write(chunk)
+                downloaded += len(chunk)
+                if progress_callback and total_size > 0:
+                    progress_callback(downloaded, total_size)
+
+
+def _remove_partial_file(filepath: str):
+    if os.path.exists(filepath):
+        try:
+            os.remove(filepath)
+            print(f"[INFO] 부분 다운로드 파일 삭제: {filepath}")
+        except OSError:
+            pass


### PR DESCRIPTION
- fix: IncompleteRead/ChunkedEncodingError 발생 시 지수 백오프 재시도 (최대 3회)
- fix: requests.get에 timeout 추가 (connect: 10s, read: 60s)
- perf: 다운로드 청크 크기 8KB → 64KB로 증가
- fix: UserSetting에 누락된 OPENAI_API_KEY 속성 추가
- refactor: 다운로드 워커의 URL 사전 로깅 루프 제거 (오해 유발 로직)
- style: 미사용 import 제거 (sys, os in summarizer/pipeline)
- style: import 정렬 (stdlib → third-party → local)
- docs: src/main.py에 deprecated 경고 추가