### PR TITLE
feat: 릴리즈 파이프라인 구축 (v0.1.0-beta)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,147 @@
+name: Release Build
+
+on:
+  push:
+    tags:
+      - 'v*'     # v0.1.0-beta, v1.0.0 등 v로 시작하는 태그
+
+permissions:
+  contents: write  # GitHub Release 생성 권한
+
+jobs:
+  # ── Mac 빌드 ──────────────────────────────────────────────────────
+  build-mac:
+    name: Build (macOS)
+    runs-on: macos-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Python 설정
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: uv 설치
+        uses: astral-sh/setup-uv@v4
+
+      - name: ffmpeg 설치
+        run: brew install ffmpeg
+
+      - name: 의존성 설치
+        run: |
+          uv sync
+          uv pip install pyinstaller
+
+      - name: Whisper 모델 다운로드 (base, ~142MB)
+        run: uv run python -c "import whisper; whisper.load_model('base')"
+
+      - name: PyInstaller 빌드
+        run: uv run pyinstaller lms-summarizer.spec
+
+      - name: ZIP 패키징
+        run: |
+          TAG="${{ github.ref_name }}"
+          cd dist
+          zip -qr "LMS-Summarizer-${TAG}-mac.zip" "LMS-Summarizer.app"
+          echo "ZIP_NAME=LMS-Summarizer-${TAG}-mac.zip" >> $GITHUB_ENV
+
+      - name: 빌드 아티팩트 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-build
+          path: dist/${{ env.ZIP_NAME }}
+          retention-days: 7
+
+  # ── Windows 빌드 ──────────────────────────────────────────────────
+  build-windows:
+    name: Build (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Python 설정
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: uv 설치
+        uses: astral-sh/setup-uv@v4
+
+      - name: ffmpeg 설치
+        run: choco install ffmpeg -y
+
+      - name: 의존성 설치 (torch CPU-only, 용량 절감)
+        run: |
+          uv sync
+          uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+          uv pip install pyinstaller
+
+      - name: Whisper 모델 다운로드 (base, ~142MB)
+        run: uv run python -c "import whisper; whisper.load_model('base')"
+
+      - name: PyInstaller 빌드
+        run: uv run pyinstaller lms-summarizer.spec
+
+      - name: ZIP 패키징
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $zipName = "LMS-Summarizer-${tag}-windows.zip"
+          Compress-Archive -Path "dist\LMS-Summarizer" -DestinationPath "dist\$zipName" -Force
+          echo "ZIP_NAME=$zipName" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: 빌드 아티팩트 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: dist/${{ env.ZIP_NAME }}
+          retention-days: 7
+
+  # ── GitHub Release 생성 ──────────────────────────────────────────
+  release:
+    name: GitHub Release
+    needs: [build-mac, build-windows]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mac 빌드 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: mac-build
+          path: artifacts/
+
+      - name: Windows 빌드 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build
+          path: artifacts/
+
+      - name: GitHub Release 생성 및 파일 업로드
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: LMS Summarizer ${{ github.ref_name }}
+          body: |
+            ## LMS Summarizer ${{ github.ref_name }}
+
+            숭실대학교 LMS 강의 동영상 자동 다운로드 및 AI 요약 도구
+
+            ### 다운로드
+            - **Mac**: `LMS-Summarizer-*-mac.zip` 다운로드 → 압축 해제 → `.app` 실행
+            - **Windows**: `LMS-Summarizer-*-windows.zip` 다운로드 → 압축 해제 → `.exe` 실행
+
+            ### 주의사항
+            - **Mac**: 처음 실행 시 Gatekeeper 경고가 표시될 수 있습니다.
+              터미널에서 `xattr -rd com.apple.quarantine LMS-Summarizer.app` 실행 후 재시도
+            - **공통**: 시스템에 Google Chrome이 설치되어 있어야 합니다.
+            - Gemini API 키가 필요합니다 (https://aistudio.google.com)
+
+            ### 변경사항
+            변경사항은 커밋 히스토리를 참고해주세요.
+          files: artifacts/*
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
+          draft: false

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!lms-summarizer.spec
+
+# 사용자 설정 파일 (로컬 전용)
+src/settings.json
+settings.json
 
 # Installer logs
 pip-log.txt

--- a/build_mac_pyinstaller.sh
+++ b/build_mac_pyinstaller.sh
@@ -1,153 +1,92 @@
 #!/bin/bash
+#
+# LMS Summarizer - Mac .app 빌드 스크립트
+# 사용법: ./build_mac_pyinstaller.sh
+#
 
-# LMS 요약 도구 Mac .app 빌드 스크립트 (PyInstaller 사용)
-# 설명: PyInstaller를 사용하여 GUI 애플리케이션을 Mac .app 번들로 변환
+set -e
 
-set -e  # 오류 발생 시 스크립트 중단
+APP_VERSION="0.1.0-beta"
+APP_NAME="LMS-Summarizer"
 
-echo "🚀 LMS 요약 도구 Mac 앱 빌드를 시작합니다 (PyInstaller 사용)..."
+echo "🚀 LMS Summarizer v${APP_VERSION} Mac 빌드 시작..."
 
-# 현재 디렉토리 확인
+# 프로젝트 루트 확인
 if [ ! -f "src/gui/main.py" ]; then
-    echo "❌ src/gui/main.py 파일을 찾을 수 없습니다. 프로젝트 루트 디렉토리에서 실행해주세요."
+    echo "❌ src/gui/main.py를 찾을 수 없습니다. 프로젝트 루트에서 실행해주세요."
     exit 1
 fi
 
-# uv 설치 확인
+# uv 확인
 if ! command -v uv &> /dev/null; then
-    echo "❌ uv가 설치되어 있지 않습니다. https://docs.astral.sh/uv/getting-started/installation/"
+    echo "❌ uv가 없습니다: https://docs.astral.sh/uv/"
     exit 1
 fi
 
+# ffmpeg 확인
+FFMPEG_PATH=""
+for path in "/opt/homebrew/bin/ffmpeg" "/usr/local/bin/ffmpeg" "/usr/bin/ffmpeg"; do
+    if [ -f "$path" ]; then
+        FFMPEG_PATH="$path"
+        break
+    fi
+done
+if [ -z "$FFMPEG_PATH" ]; then
+    echo "❌ ffmpeg를 찾을 수 없습니다."
+    echo "   설치: brew install ffmpeg"
+    exit 1
+fi
+echo "✅ ffmpeg: $FFMPEG_PATH"
+
+# Whisper 모델 사전 다운로드 (base 모델 ~142MB)
+echo "📥 Whisper base 모델 확인 중..."
+uv run python -c "import whisper; whisper.load_model('base'); print('✅ 모델 준비 완료')"
+
+# 의존성 설치
 echo "📦 의존성 설치 중..."
 uv sync
-
-echo "📦 PyInstaller를 설치합니다..."
 uv pip install pyinstaller
 
-# 기존 빌드 파일들 정리
-echo "🧹 기존 빌드 파일들을 정리합니다..."
-rm -rf build/ dist/ *.spec
+# 기존 빌드 정리
+echo "🧹 이전 빌드 파일 정리..."
+rm -rf build/ dist/
 
-echo "📦 ffmpeg 복사 중..."
-if [ -f "/usr/local/bin/ffmpeg" ]; then
-    FFMPEG_PATH="/usr/local/bin/ffmpeg"
-elif [ -f "/opt/homebrew/bin/ffmpeg" ]; then
-    FFMPEG_PATH="/opt/homebrew/bin/ffmpeg"
-else
-    echo "❌ ffmpeg를 찾을 수 없습니다. 설치가 필요합니다."
-    exit 1
-fi
-
-echo "📦 Whisper 모델 다운로드 중..."
-python3 -c "import whisper; whisper.load_model('base')"
-
-echo "🔨 .app 번들을 빌드합니다..."
-
-# PyInstaller로 Mac 앱 빌드
-pyinstaller \
-    --name="LMS-Summarizer" \
-    --windowed \
-    --onedir \
-    --add-data="src:src" \
-    --add-data="requirements.txt:." \
-    --add-binary="${FFMPEG_PATH}:." \
-    --add-data="$HOME/.cache/whisper:whisper_models" \
-    --paths="src" \
-    --paths="src/video_pipeline" \
-    --paths="src/audio_pipeline" \
-    --paths="src/summarize_pipeline" \
-    --hidden-import=PyQt5 \
-    --hidden-import=PyQt5.QtCore \
-    --hidden-import=PyQt5.QtWidgets \
-    --hidden-import=PyQt5.QtGui \
-    --hidden-import=openai \
-    --hidden-import=whisper \
-    --hidden-import=playwright \
-    --hidden-import=requests \
-    --hidden-import=dotenv \
-    --hidden-import=json \
-    --hidden-import=threading \
-    --hidden-import=src.user_setting \
-    --hidden-import=src.video_pipeline.pipeline \
-    --hidden-import=src.audio_pipeline.pipeline \
-    --hidden-import=src.summarize_pipeline.pipeline \
-    --hidden-import=src.video_pipeline.login \
-    --hidden-import=src.video_pipeline.video_parser \
-    --hidden-import=src.video_pipeline.download_video \
-    --hidden-import=src.audio_pipeline.converter \
-    --hidden-import=src.audio_pipeline.transcriber \
-    --hidden-import=src.summarize_pipeline.summarizer \
-    --collect-all=whisper \
-    --collect-all=torch \
-    --collect-all=torchaudio \
-    --collect-all=openai \
-    --collect-submodules=src \
-    --exclude-module=tkinter \
-    --exclude-module=matplotlib \
-    --exclude-module=PIL \
-    src/gui/main.py
+# spec 파일로 빌드
+echo "🔨 PyInstaller 빌드 시작..."
+uv run pyinstaller lms-summarizer.spec
 
 # 빌드 결과 확인
-if [ -d "dist/LMS-Summarizer.app" ]; then
-    echo "✅ .app 번들 생성 완료!"
-    
-    # 앱 정보 출력
-    echo "📱 생성된 앱: dist/LMS-Summarizer.app"
-    echo "📏 앱 크기: $(du -sh dist/LMS-Summarizer.app | cut -f1)"
-    
-    # ZIP 파일로도 압축
-    echo "📦 배포용 ZIP 파일을 생성합니다..."
-    cd dist
-    zip -r "LMS-Summarizer-Mac.zip" "LMS-Summarizer.app"
-    cd ..
-    
-    echo "✅ 빌드 완료!"
-    echo "📁 결과물:"
-    echo "   - dist/LMS-Summarizer.app (Mac 애플리케이션)"
-    echo "   - dist/LMS-Summarizer-Mac.zip (배포용 ZIP)"
-    echo ""
-    echo "🚀 애플리케이션을 실행하려면:"
-    echo "   open dist/LMS-Summarizer.app"
-    
-    # 애플리케이션 정보 설정
-    echo "📝 애플리케이션 정보를 설정합니다..."
-    INFO_PLIST="dist/LMS-Summarizer.app/Contents/Info.plist"
-    if [ -f "$INFO_PLIST" ]; then
-        # CFBundleDisplayName 추가
-        /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName 'LMS 강의 다운로드 & 요약'" "$INFO_PLIST" 2>/dev/null || \
-        /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string 'LMS 강의 다운로드 & 요약'" "$INFO_PLIST"
-        
-        # CFBundleVersion 설정
-        /usr/libexec/PlistBuddy -c "Set :CFBundleVersion '1.0.0'" "$INFO_PLIST" 2>/dev/null || \
-        /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string '1.0.0'" "$INFO_PLIST"
-        
-        # CFBundleShortVersionString 설정
-        /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString '1.0.0'" "$INFO_PLIST" 2>/dev/null || \
-        /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string '1.0.0'" "$INFO_PLIST"
-        
-        # NSHighResolutionCapable 설정
-        /usr/libexec/PlistBuddy -c "Set :NSHighResolutionCapable true" "$INFO_PLIST" 2>/dev/null || \
-        /usr/libexec/PlistBuddy -c "Add :NSHighResolutionCapable bool true" "$INFO_PLIST"
-        
-        echo "✅ 애플리케이션 정보 설정 완료"
-    fi
-    
-else
-    echo "❌ .app 번들 생성에 실패했습니다."
-    echo "빌드 로그를 확인해주세요."
+DIST_APP="dist/${APP_NAME}.app"
+if [ ! -d "$DIST_APP" ]; then
+    echo "❌ 빌드 실패: $DIST_APP 를 찾을 수 없습니다."
     exit 1
 fi
 
-# 정리
-echo "🧹 임시 파일들을 정리합니다..."
-rm -rf build/ *.spec
+APP_SIZE=$(du -sh "$DIST_APP" | cut -f1)
+echo "✅ .app 번들 생성 완료!"
+echo "   경로: $DIST_APP"
+echo "   크기: $APP_SIZE"
 
-echo "🎉 Mac 앱 빌드가 완료되었습니다!"
+# 배포용 ZIP 생성
+ZIP_NAME="${APP_NAME}-v${APP_VERSION}-mac.zip"
+echo "📦 배포용 ZIP 생성: dist/$ZIP_NAME"
+(cd dist && zip -qr "$ZIP_NAME" "${APP_NAME}.app")
+
+ZIP_SIZE=$(du -sh "dist/$ZIP_NAME" | cut -f1)
+echo "✅ ZIP 생성 완료: dist/$ZIP_NAME ($ZIP_SIZE)"
+
+# 임시 빌드 파일 정리
+rm -rf build/
+
 echo ""
-echo "📋 사용법:"
-echo "1. dist/LMS-Summarizer.app을 Applications 폴더로 복사"
-echo "2. 처음 실행 시 '확인되지 않은 개발자' 경고가 나타날 수 있음"
-echo "3. 시스템 환경설정 > 보안 및 개인 정보 보호에서 '확인 없이 열기' 클릭"
+echo "🎉 빌드 완료!"
 echo ""
-echo "🎯 완전한 배포용 패키지를 원한다면 create_dmg.sh를 실행하세요"
+echo "📋 결과물:"
+echo "   .app: $DIST_APP ($APP_SIZE)"
+echo "   ZIP:  dist/$ZIP_NAME ($ZIP_SIZE)"
+echo ""
+echo "🚀 실행:"
+echo "   open $DIST_APP"
+echo ""
+echo "⚠️  Gatekeeper 경고 해제 (서명 없는 앱):"
+echo "   xattr -rd com.apple.quarantine $DIST_APP"

--- a/lms-summarizer.spec
+++ b/lms-summarizer.spec
@@ -1,0 +1,145 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# LMS Summarizer - PyInstaller spec file
+#
+# 빌드 명령:
+#   Mac:     pyinstaller lms-summarizer.spec
+#   Windows: pyinstaller lms-summarizer.spec
+#
+# 용량 최적화 참고:
+#   - torch (CPU only): ~300MB  → GPU 버전 제외로 절감
+#   - whisper base 모델: ~142MB → 번들에 포함
+#   - PyQt5: ~40MB
+#   - 전체 .app 예상: ~600-800MB (압축 전), ZIP 시 ~300-400MB
+#
+# Windows에서 torch CPU only 설치 (용량 절감):
+#   pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+import sys
+import os
+from pathlib import Path
+
+APP_NAME = "LMS-Summarizer"
+APP_VERSION = "0.1.0-beta"
+
+# ffmpeg 경로 자동 탐지
+def find_ffmpeg():
+    import shutil
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+    for path in ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg"]:
+        if os.path.exists(path):
+            return path
+    raise RuntimeError(
+        "ffmpeg를 찾을 수 없습니다. 'brew install ffmpeg' 또는 "
+        "https://ffmpeg.org/download.html 에서 설치 후 빌드하세요."
+    )
+
+# Whisper 모델 캐시 경로
+def find_whisper_models():
+    home = Path.home()
+    cache = home / ".cache" / "whisper"
+    if cache.exists():
+        return str(cache)
+    return None
+
+ffmpeg_path = find_ffmpeg()
+whisper_cache = find_whisper_models()
+
+# 추가 데이터 파일
+datas = [
+    ("src", "src"),
+]
+if whisper_cache:
+    datas.append((whisper_cache, "whisper_models"))
+
+# ffmpeg 바이너리 포함
+binaries = [(ffmpeg_path, ".")]
+
+a = Analysis(
+    ["src/gui/main.py"],
+    pathex=[".", "src"],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=[
+        # PyQt5
+        "PyQt5", "PyQt5.QtCore", "PyQt5.QtWidgets", "PyQt5.QtGui",
+        # 앱 모듈
+        "src.user_setting",
+        "src.video_pipeline.pipeline",
+        "src.video_pipeline.login",
+        "src.video_pipeline.video_parser",
+        "src.video_pipeline.download_video",
+        "src.audio_pipeline.pipeline",
+        "src.audio_pipeline.converter",
+        "src.audio_pipeline.transcriber",
+        "src.summarize_pipeline.pipeline",
+        "src.summarize_pipeline.summarizer",
+        # 외부 라이브러리
+        "openai", "whisper", "playwright", "requests",
+        "dotenv", "google.generativeai",
+        # 표준 라이브러리
+        "json", "threading", "pathlib",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        # 불필요한 대용량 패키지 제외
+        "tkinter", "matplotlib", "PIL", "Pillow",
+        "scipy", "pandas", "notebook", "jupyter",
+        "IPython", "cv2", "sklearn",
+        # torch CUDA 관련 제외 (Mac/CPU-only 빌드)
+        "torch.cuda", "torch.backends.cudnn",
+    ],
+    noarchive=False,
+    optimize=1,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,        # UPX 압축 활성화 (설치 시: brew install upx)
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,   # GUI 앱: 콘솔 창 숨김
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name=APP_NAME,
+)
+
+# macOS .app 번들 생성
+if sys.platform == "darwin":
+    app = BUNDLE(
+        coll,
+        name=f"{APP_NAME}.app",
+        icon=None,
+        bundle_identifier="com.lms-summarizer.app",
+        info_plist={
+            "CFBundleDisplayName": "LMS 강의 다운로드 & 요약",
+            "CFBundleShortVersionString": APP_VERSION,
+            "CFBundleVersion": APP_VERSION,
+            "NSHighResolutionCapable": True,
+            "NSRequiresAquaSystemAppearance": False,  # Dark mode 지원
+        },
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lms-summarizer"
-version = "1.0.0"
+version = "0.1.0-beta"
 description = "숭실대학교 LMS 강의 동영상 다운로드 및 AI 요약 도구"
 requires-python = ">=3.9,<3.13"
 

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,0 +1,98 @@
+# LMS Summarizer - Windows 빌드 스크립트 (PowerShell)
+# 사용법: powershell -ExecutionPolicy Bypass -File scripts/build_windows.ps1
+#
+# 사전 요구사항:
+#   - Python 3.9-3.12 설치 (python.org)
+#   - uv 설치: winget install astral-sh.uv
+#   - ffmpeg 설치: winget install Gyan.FFmpeg (또는 PATH에 추가)
+
+$ErrorActionPreference = "Stop"
+
+$APP_VERSION = "0.1.0-beta"
+$APP_NAME = "LMS-Summarizer"
+
+Write-Host "🚀 LMS Summarizer v$APP_VERSION Windows 빌드 시작..." -ForegroundColor Cyan
+
+# 프로젝트 루트 확인
+if (-not (Test-Path "src/gui/main.py")) {
+    Write-Host "❌ src/gui/main.py를 찾을 수 없습니다. 프로젝트 루트에서 실행해주세요." -ForegroundColor Red
+    exit 1
+}
+
+# uv 확인
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Host "❌ uv가 없습니다: https://docs.astral.sh/uv/" -ForegroundColor Red
+    Write-Host "   설치: winget install astral-sh.uv" -ForegroundColor Yellow
+    exit 1
+}
+
+# ffmpeg 확인
+$ffmpegPath = (Get-Command ffmpeg -ErrorAction SilentlyContinue)?.Source
+if (-not $ffmpegPath) {
+    $candidates = @(
+        "$env:LOCALAPPDATA\Microsoft\WinGet\Links\ffmpeg.exe",
+        "C:\ffmpeg\bin\ffmpeg.exe",
+        "C:\Program Files\ffmpeg\bin\ffmpeg.exe"
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path $c) { $ffmpegPath = $c; break }
+    }
+}
+if (-not $ffmpegPath) {
+    Write-Host "❌ ffmpeg를 찾을 수 없습니다." -ForegroundColor Red
+    Write-Host "   설치: winget install Gyan.FFmpeg" -ForegroundColor Yellow
+    exit 1
+}
+Write-Host "✅ ffmpeg: $ffmpegPath" -ForegroundColor Green
+
+# Whisper 모델 사전 다운로드
+Write-Host "📥 Whisper base 모델 확인 중..."
+uv run python -c "import whisper; whisper.load_model('base'); print('✅ 모델 준비 완료')"
+
+# 의존성 설치
+Write-Host "📦 의존성 설치 중..."
+uv sync
+# Windows에서 torch CPU-only 설치로 용량 절감 (~300MB 절약)
+# GPU 사용이 필요하면 아래 줄을 제거하세요
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+uv pip install pyinstaller
+
+# 이전 빌드 정리
+Write-Host "🧹 이전 빌드 파일 정리..."
+if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
+if (Test-Path "dist") { Remove-Item -Recurse -Force "dist" }
+
+# spec 파일로 빌드
+Write-Host "🔨 PyInstaller 빌드 시작..."
+uv run pyinstaller lms-summarizer.spec
+
+# 빌드 결과 확인
+$distExe = "dist\$APP_NAME\$APP_NAME.exe"
+if (-not (Test-Path $distExe)) {
+    Write-Host "❌ 빌드 실패: $distExe 를 찾을 수 없습니다." -ForegroundColor Red
+    exit 1
+}
+
+$distDir = "dist\$APP_NAME"
+$dirSize = [math]::Round((Get-ChildItem $distDir -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB, 1)
+Write-Host "✅ 빌드 완료! 크기: ${dirSize}MB" -ForegroundColor Green
+
+# 배포용 ZIP 생성
+$zipName = "$APP_NAME-v$APP_VERSION-windows.zip"
+Write-Host "📦 배포용 ZIP 생성: dist\$zipName"
+Compress-Archive -Path $distDir -DestinationPath "dist\$zipName" -Force
+
+$zipSize = [math]::Round((Get-Item "dist\$zipName").Length / 1MB, 1)
+Write-Host "✅ ZIP 생성 완료: dist\$zipName (${zipSize}MB)" -ForegroundColor Green
+
+# 임시 빌드 파일 정리
+if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
+
+Write-Host ""
+Write-Host "🎉 빌드 완료!" -ForegroundColor Green
+Write-Host ""
+Write-Host "📋 결과물:"
+Write-Host "   폴더: $distDir (${dirSize}MB)"
+Write-Host "   ZIP:  dist\$zipName (${zipSize}MB)"
+Write-Host ""
+Write-Host "🚀 실행: dist\$APP_NAME\$APP_NAME.exe"

--- a/src/gui/config/constants.py
+++ b/src/gui/config/constants.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 # 앱 기본 정보
 APP_TITLE = "LMS 강의 다운로드 & 요약"
-APP_VERSION = "v1.0"
+APP_VERSION = "v0.1.0-beta"
 WINDOW_WIDTH = 660
 WINDOW_HEIGHT = 600
 MIN_WINDOW_WIDTH = 580


### PR DESCRIPTION
- APP_VERSION을 v0.1.0-beta로 업데이트 (pyproject.toml, constants.py)
- lms-summarizer.spec: PyInstaller 빌드 설정 파일 추가
  - ffmpeg 자동 탐지 및 포함
  - Whisper base 모델 사전 번들링
  - torch CUDA 관련 모듈 제외 (용량 절감)
  - macOS .app 번들 Info.plist 자동 설정
- build_mac_pyinstaller.sh: spec 파일 기반으로 리팩토링
- scripts/build_windows.ps1: Windows PowerShell 빌드 스크립트 추가
  - torch CPU-only 설치로 용량 절감 (~300MB)
- .github/workflows/release.yml: GitHub Actions CI/CD 추가
  - v* 태그 push 시 Mac/Windows 자동 빌드
  - GitHub Releases에 자동 업로드
  - beta/alpha/rc 태그는 pre-release로 표시