### PR TITLE
feat: 설정 다이얼로그 추가 (프롬프트, Chrome 경로)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,4 +198,5 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
-user_settings.json
+user_settings.json.claude/
+.claude/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyperclip>=1.9.0",
     "PyQt5>=5.15.11",
     "python-dotenv>=1.1.0",
+    "qtawesome>=1.4.1",
     "requests>=2.32.3",
     "torch>=2.7.0",
 ]

--- a/src/gui/config/settings.py
+++ b/src/gui/config/settings.py
@@ -14,6 +14,7 @@ class InputFieldConfig:
     is_password: bool = False
     is_multiline: bool = False
     max_height: Optional[int] = None
+    icon: Optional[str] = None
 
 
 @dataclass
@@ -27,22 +28,26 @@ class ModuleConfig:
 # 입력 필드 설정들
 INPUT_FIELD_CONFIGS = {
     'student_id': InputFieldConfig(
-        label="📚 학번:",
-        placeholder="예: 20201234"
+        label="학번:",
+        placeholder="예: 20201234",
+        icon="school",
     ),
     'password': InputFieldConfig(
-        label="🔒 비밀번호:",
+        label="비밀번호:",
         placeholder="LMS 비밀번호",
-        is_password=True
+        is_password=True,
+        icon="lock",
     ),
     'api_key': InputFieldConfig(
-        label="🔑 Gemini API 키:",
-        placeholder="sk-... (Gemini API 키를 입력하세요)"
+        label="Gemini API 키:",
+        placeholder="sk-... (Gemini API 키를 입력하세요)",
+        icon="key",
     ),
     'urls': InputFieldConfig(
-        label="🎬 강의 URL 목록:",
+        label="강의 URL 목록:",
         placeholder="https://canvas.ssu.ac.kr/courses/...\n(여러 URL은 각각 새 줄에 입력)",
         is_multiline=True,
+        icon="movie",
     )
 }
 

--- a/src/gui/config/styles.py
+++ b/src/gui/config/styles.py
@@ -404,3 +404,20 @@ class StyleSheet:
                 QPushButton:disabled {{ background-color: {Colors.DISABLED_BG}; color: white; }}
             """
         return f"QPushButton {{ {common} border: none; }}"
+
+    @staticmethod
+    def path_suggestion_button() -> str:
+        return f"""
+            QPushButton {{
+                background: none;
+                border: none;
+                color: {Colors.PRIMARY};
+                font-size: 11px;
+                text-align: left;
+                padding: 2px 4px;
+            }}
+            QPushButton:hover {{
+                color: {Colors.PRIMARY_HOVER};
+                text-decoration: underline;
+            }}
+        """

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -144,3 +144,64 @@ def load_user_inputs() -> Dict[str, str]:
 def get_downloads_dir() -> str:
     """다운로드 디렉토리 경로 반환 (사용자 설정 경로 사용)"""
     return ensure_downloads_directory()
+
+
+# ── 요약 프롬프트 ──────────────────────────────────────────
+
+DEFAULT_PROMPT = "다음 강의 내용을 한국어로 자세히 요약해주세요."
+
+
+def get_summary_prompt() -> str:
+    """저장된 요약 프롬프트 반환. 없으면 기본 프롬프트."""
+    return load_settings().get("summary_prompt", DEFAULT_PROMPT)
+
+
+def set_summary_prompt(prompt: str) -> None:
+    """요약 프롬프트를 settings.json에 저장"""
+    settings = load_settings()
+    settings["summary_prompt"] = prompt
+    save_settings(settings)
+
+
+# ── Chrome 경로 ────────────────────────────────────────────
+
+_CHROME_PATHS = {
+    'darwin': [
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    ],
+    'win32': [
+        r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+    ],
+    'linux': [
+        "/usr/bin/google-chrome",
+        "/usr/bin/google-chrome-stable",
+        "/usr/bin/chromium-browser",
+        "/usr/bin/chromium",
+    ],
+}
+
+
+def detect_chrome_paths() -> List[str]:
+    """현재 OS에서 Chrome 설치 경로 후보를 반환 (존재하는 경로만)"""
+    candidates = _CHROME_PATHS.get(sys.platform, _CHROME_PATHS.get('linux', []))
+    return [p for p in candidates if os.path.exists(p)]
+
+
+def get_chrome_path() -> str:
+    """저장된 Chrome 경로 반환. 없으면 자동 감지된 첫 번째 경로."""
+    settings = load_settings()
+    saved = settings.get("chrome_path", "")
+    if saved and os.path.exists(saved):
+        return saved
+    detected = detect_chrome_paths()
+    return detected[0] if detected else ""
+
+
+def set_chrome_path(path: str) -> None:
+    """Chrome 경로를 settings.json에 저장"""
+    settings = load_settings()
+    settings["chrome_path"] = path
+    save_settings(settings)

--- a/src/gui/ui/components/buttons.py
+++ b/src/gui/ui/components/buttons.py
@@ -3,10 +3,10 @@
 """
 
 from PyQt5.QtWidgets import QPushButton
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QSize
 
 from src.gui.config.styles import StyleSheet
-from src.gui.config.constants import EMOJI_START, EMOJI_STOP
+from src.gui.ui.components.icons import AppIcons
 
 
 class AppButton(QPushButton):
@@ -17,6 +17,7 @@ class AppButton(QPushButton):
         self.setCursor(Qt.PointingHandCursor)
         self._variant = variant
         self.setStyleSheet(StyleSheet.app_button(variant))
+        self.setIconSize(QSize(18, 18))
 
     def set_variant(self, variant: str):
         """버튼 스타일 변형 변경"""
@@ -28,20 +29,23 @@ class ProcessingButton(AppButton):
     """처리 작업용 버튼 (시작 ↔ 중지 전환)"""
 
     def __init__(self):
-        super().__init__(f"{EMOJI_START} 요약 시작", "filled")
+        super().__init__("요약 시작", "filled")
+        self.setIcon(AppIcons.icon('start', color='white'))
         self.is_processing = False
 
     def start_processing(self):
         """처리 시작 → 중지 버튼으로 변경"""
         self.is_processing = True
-        self.setText(f"{EMOJI_STOP} 중지")
+        self.setText("중지")
+        self.setIcon(AppIcons.icon('stop', color='white'))
         self.set_variant("danger")
         self.setEnabled(True)
 
     def stop_processing(self):
         """처리 완료 → 시작 버튼으로 복원"""
         self.is_processing = False
-        self.setText(f"{EMOJI_START} 요약 시작")
+        self.setText("요약 시작")
+        self.setIcon(AppIcons.icon('start', color='white'))
         self.set_variant("filled")
         self.setEnabled(True)
 
@@ -51,12 +55,14 @@ class ProcessingButton(AppButton):
         if text:
             self.setText(text)
         elif enabled and not self.is_processing:
-            self.setText(f"{EMOJI_START} 요약 시작")
+            self.setText("요약 시작")
+            self.setIcon(AppIcons.icon('start', color='white'))
 
 
 class ClearButton(AppButton):
     """초기화 버튼"""
 
     def __init__(self):
-        super().__init__("🗑️ 초기화", "danger")
+        super().__init__("초기화", "danger")
+        self.setIcon(AppIcons.icon('delete', color='white'))
         self.setToolTip("모든 입력 필드를 초기화합니다")

--- a/src/gui/ui/components/icons.py
+++ b/src/gui/ui/components/icons.py
@@ -95,23 +95,41 @@ class IconLabel(QWidget):
     def __init__(self, icon_name: str, text: str, icon_size: int = 16,
                  icon_color: str = None, parent: QWidget = None):
         super().__init__(parent)
+
+        # 투명 배경 - 부모 위젯의 스타일이 투과되어 outline이 생기지 않도록
+        super().setStyleSheet("background: transparent; border: none;")
+
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
 
         self._icon_label = QLabel()
         self._icon_label.setPixmap(AppIcons.pixmap(icon_name, icon_size, icon_color))
-        self._icon_label.setFixedSize(icon_size + 2, icon_size + 2)
+        self._icon_label.setFixedSize(icon_size, icon_size)
         self._icon_label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self._icon_label)
+        self._icon_label.setStyleSheet("background: transparent; border: none;")
+        layout.addWidget(self._icon_label, alignment=Qt.AlignVCenter)
 
         self._text_label = QLabel(text)
-        layout.addWidget(self._text_label)
+        self._text_label.setStyleSheet("background: transparent; border: none;")
+        layout.addWidget(self._text_label, alignment=Qt.AlignVCenter)
         layout.addStretch()
 
     def setStyleSheet(self, style: str):
-        """텍스트 라벨에 스타일시트 적용"""
-        self._text_label.setStyleSheet(style)
+        """텍스트 라벨에 스타일시트 적용 (배경 투명, margin은 위젯 레벨로 이동)"""
+        # margin-top은 위젯 자체에 적용하여 아이콘-텍스트가 정렬되도록
+        import re
+        margin_match = re.search(r'margin-top:\s*(\d+)px', style)
+        if margin_match:
+            margin_val = margin_match.group(1)
+            super().setStyleSheet(
+                f"background: transparent; border: none; margin-top: {margin_val}px;"
+            )
+            # 텍스트 라벨에서는 margin-top 제거
+            cleaned = re.sub(r'margin-top:\s*\d+px;?\s*', '', style)
+            self._text_label.setStyleSheet(cleaned + " background: transparent; border: none;")
+        else:
+            self._text_label.setStyleSheet(style + " background: transparent; border: none;")
 
     def setAlignment(self, alignment):
         """텍스트 정렬"""

--- a/src/gui/ui/components/icons.py
+++ b/src/gui/ui/components/icons.py
@@ -1,0 +1,132 @@
+"""
+Material Design Icons 제공 모듈 (qtawesome 기반)
+
+사용법:
+    from src.gui.ui.components.icons import AppIcons
+
+    # 버튼에 아이콘 추가
+    button.setIcon(AppIcons.icon('settings'))
+
+    # 아이콘 + 텍스트 복합 라벨 생성
+    label = AppIcons.label('folder', '저장 경로:')
+"""
+
+import qtawesome as qta
+from PyQt5.QtGui import QIcon, QPixmap
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QLabel
+from PyQt5.QtCore import QSize, Qt
+
+from src.gui.config.constants import Colors
+
+
+# 아이콘 이름 매핑 (앱 내부 → Material Design Icons 6)
+_ICON_MAP = {
+    # 버튼
+    'start': 'mdi6.play',
+    'stop': 'mdi6.stop',
+    'delete': 'mdi6.delete',
+    'settings': 'mdi6.cog',
+    'folder_open': 'mdi6.folder-open',
+    'save': 'mdi6.content-save',
+    'cancel': 'mdi6.close',
+    'reset': 'mdi6.restore',
+    'browse': 'mdi6.folder-search',
+
+    # 비밀번호 토글
+    'visibility': 'mdi6.eye-outline',
+    'visibility_off': 'mdi6.eye-off-outline',
+
+    # 입력 필드 라벨
+    'school': 'mdi6.school',
+    'lock': 'mdi6.lock',
+    'key': 'mdi6.key-variant',
+    'movie': 'mdi6.movie-open',
+
+    # 섹션 헤더
+    'graduation': 'mdi6.school',
+    'book': 'mdi6.book-open-variant',
+    'folder': 'mdi6.folder',
+    'robot': 'mdi6.robot',
+    'video': 'mdi6.video',
+    'log': 'mdi6.clipboard-text-outline',
+    'prompt': 'mdi6.text-box-edit-outline',
+    'chrome': 'mdi6.google-chrome',
+
+    # 진행 상태
+    'check_circle': 'mdi6.check-circle',
+    'circle_outline': 'mdi6.circle-outline',
+    'record_circle': 'mdi6.record-circle',
+    'chevron_down': 'mdi6.chevron-down',
+    'chevron_up': 'mdi6.chevron-up',
+
+    # 기타
+    'warning': 'mdi6.alert-outline',
+    'processing': 'mdi6.timer-sand',
+}
+
+_DEFAULT_COLOR = Colors.TEXT_SECONDARY
+
+
+class AppIcons:
+    """앱 전체에서 사용하는 아이콘 관리 클래스"""
+
+    @staticmethod
+    def icon(name: str, color: str = None) -> QIcon:
+        """QIcon 반환 (QPushButton.setIcon 등에 사용)"""
+        qta_name = _ICON_MAP.get(name, name)
+        return qta.icon(qta_name, color=color or _DEFAULT_COLOR)
+
+    @staticmethod
+    def pixmap(name: str, size: int = 16, color: str = None) -> QPixmap:
+        """QPixmap 반환 (QLabel.setPixmap 등에 사용)"""
+        ic = AppIcons.icon(name, color=color)
+        return ic.pixmap(QSize(size, size))
+
+    @staticmethod
+    def label(icon_name: str, text: str, icon_size: int = 16,
+              icon_color: str = None, parent: QWidget = None) -> 'IconLabel':
+        """아이콘 + 텍스트 복합 라벨 생성"""
+        return IconLabel(icon_name, text, icon_size, icon_color, parent)
+
+
+class IconLabel(QWidget):
+    """아이콘 + 텍스트가 결합된 라벨 위젯"""
+
+    def __init__(self, icon_name: str, text: str, icon_size: int = 16,
+                 icon_color: str = None, parent: QWidget = None):
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self._icon_label = QLabel()
+        self._icon_label.setPixmap(AppIcons.pixmap(icon_name, icon_size, icon_color))
+        self._icon_label.setFixedSize(icon_size + 2, icon_size + 2)
+        self._icon_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self._icon_label)
+
+        self._text_label = QLabel(text)
+        layout.addWidget(self._text_label)
+        layout.addStretch()
+
+    def setStyleSheet(self, style: str):
+        """텍스트 라벨에 스타일시트 적용"""
+        self._text_label.setStyleSheet(style)
+
+    def setAlignment(self, alignment):
+        """텍스트 정렬"""
+        self._text_label.setAlignment(alignment)
+
+    def setEnabled(self, enabled: bool):
+        """활성화 상태 설정"""
+        super().setEnabled(enabled)
+        self._text_label.setEnabled(enabled)
+        self._icon_label.setEnabled(enabled)
+
+    def setVisible(self, visible: bool):
+        """표시 상태 설정"""
+        super().setVisible(visible)
+
+    def setWordWrap(self, wrap: bool):
+        """줄바꿈 설정"""
+        self._text_label.setWordWrap(wrap)

--- a/src/gui/ui/components/input_field.py
+++ b/src/gui/ui/components/input_field.py
@@ -3,11 +3,12 @@
 """
 
 from PyQt5.QtWidgets import QLabel, QLineEdit, QTextEdit, QPushButton, QHBoxLayout, QWidget, QVBoxLayout
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, QSize, pyqtSignal
 from PyQt5.QtGui import QInputMethodEvent
 
 from src.gui.config.settings import InputFieldConfig
 from src.gui.config.styles import StyleSheet
+from src.gui.ui.components.icons import AppIcons
 
 
 class PasswordToggleButton(QPushButton):
@@ -18,13 +19,17 @@ class PasswordToggleButton(QPushButton):
         self.setCheckable(True)
         self.setCursor(Qt.PointingHandCursor)
         self.setFixedWidth(38)
+        self.setIconSize(QSize(18, 18))
         self.setToolTip("비밀번호 표시/숨기기")
         self._update_icon(False)
         self.setStyleSheet(self._style())
         self.toggled.connect(self._update_icon)
 
     def _update_icon(self, checked: bool):
-        self.setText("👁" if not checked else "🙈")
+        if checked:
+            self.setIcon(AppIcons.icon('visibility_off'))
+        else:
+            self.setIcon(AppIcons.icon('visibility'))
 
     @staticmethod
     def _style() -> str:
@@ -159,8 +164,12 @@ class InputField:
         if self.config.is_password:
             self._setup_caps_lock_label()
 
-    def _create_label(self) -> QLabel:
-        """라벨 생성"""
+    def _create_label(self):
+        """라벨 생성 (아이콘이 설정된 경우 IconLabel 사용)"""
+        if self.config.icon:
+            label = AppIcons.label(self.config.icon, self.config.label)
+            label.setStyleSheet(StyleSheet.label())
+            return label
         label = QLabel(self.config.label)
         label.setStyleSheet(StyleSheet.label())
         return label
@@ -196,7 +205,8 @@ class InputField:
 
     def _setup_caps_lock_label(self):
         """Caps Lock 경고 라벨 설정"""
-        self.caps_lock_label = QLabel("⚠ Caps Lock이 켜져 있습니다")
+        self.caps_lock_label = AppIcons.label('warning', "Caps Lock이 켜져 있습니다",
+                                               icon_color="#F57C00")
         self.caps_lock_label.setStyleSheet(StyleSheet.caps_lock_warning())
         self.caps_lock_label.setVisible(False)
         self.widget.caps_lock_changed.connect(self.caps_lock_label.setVisible)

--- a/src/gui/ui/components/log_area.py
+++ b/src/gui/ui/components/log_area.py
@@ -7,6 +7,7 @@ from PyQt5.QtCore import Qt
 
 from src.gui.config.styles import StyleSheet
 from src.gui.config.constants import Limits
+from src.gui.ui.components.icons import AppIcons
 
 
 class LogArea:
@@ -16,9 +17,9 @@ class LogArea:
         self.label = self._create_label()
         self.text_area = self._create_text_area()
 
-    def _create_label(self) -> QLabel:
+    def _create_label(self):
         """로그 라벨 생성"""
-        label = QLabel("📋 작업 로그:")
+        label = AppIcons.label('log', '작업 로그:')
         label.setStyleSheet(StyleSheet.label())
         return label
 
@@ -28,7 +29,7 @@ class LogArea:
         text_area.setReadOnly(True)
         text_area.setStyleSheet(StyleSheet.log_area())
         text_area.setMinimumHeight(Limits.LOG_AREA_MIN_HEIGHT)
-        text_area.setPlainText("📋 작업 로그가 여기에 표시됩니다...\n")
+        text_area.setPlainText("작업 로그가 여기에 표시됩니다...\n")
         return text_area
 
     def append_message(self, message: str):
@@ -39,7 +40,7 @@ class LogArea:
     def clear(self):
         """로그 초기화"""
         self.text_area.clear()
-        self.text_area.setPlainText("📋 작업 로그가 여기에 표시됩니다...\n")
+        self.text_area.setPlainText("작업 로그가 여기에 표시됩니다...\n")
 
     def _auto_scroll(self):
         """자동 스크롤"""

--- a/src/gui/ui/dialogs/progress_modal.py
+++ b/src/gui/ui/dialogs/progress_modal.py
@@ -6,9 +6,10 @@ from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QProgressBar, QTextEdit, QFrame
 )
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, QSize, pyqtSignal
 
 from src.gui.config.styles import StyleSheet
+from src.gui.ui.components.icons import AppIcons
 
 # 처리 단계 정의: (단계번호, 표시 이름)
 _STEPS = [
@@ -80,7 +81,9 @@ class ProcessingModal(QDialog):
         layout.addWidget(self._progress_bar)
 
         # 로그 토글 버튼
-        self._log_toggle_btn = QPushButton("▼ 상세 로그 보기")
+        self._log_toggle_btn = QPushButton("상세 로그 보기")
+        self._log_toggle_btn.setIcon(AppIcons.icon('chevron_down'))
+        self._log_toggle_btn.setIconSize(QSize(16, 16))
         self._log_toggle_btn.setStyleSheet(StyleSheet.modal_log_toggle())
         self._log_toggle_btn.setCursor(Qt.PointingHandCursor)
         self._log_toggle_btn.clicked.connect(self._toggle_log)
@@ -97,7 +100,9 @@ class ProcessingModal(QDialog):
         # 하단 버튼 영역
         btn_layout = QHBoxLayout()
         btn_layout.addStretch()
-        self._stop_btn = QPushButton("■ 중지")
+        self._stop_btn = QPushButton("중지")
+        self._stop_btn.setIcon(AppIcons.icon('stop', color='white'))
+        self._stop_btn.setIconSize(QSize(16, 16))
         self._stop_btn.setStyleSheet(StyleSheet.modal_stop_button())
         self._stop_btn.setCursor(Qt.PointingHandCursor)
         self._stop_btn.clicked.connect(self._on_stop_clicked)
@@ -115,9 +120,12 @@ class ProcessingModal(QDialog):
     def _toggle_log(self):
         self._log_visible = not self._log_visible
         self._log_area.setVisible(self._log_visible)
-        self._log_toggle_btn.setText(
-            "▲ 상세 로그 숨기기" if self._log_visible else "▼ 상세 로그 보기"
-        )
+        if self._log_visible:
+            self._log_toggle_btn.setText("상세 로그 숨기기")
+            self._log_toggle_btn.setIcon(AppIcons.icon('chevron_up'))
+        else:
+            self._log_toggle_btn.setText("상세 로그 보기")
+            self._log_toggle_btn.setIcon(AppIcons.icon('chevron_down'))
         self.adjustSize()
 
     def _on_stop_clicked(self):

--- a/src/gui/ui/dialogs/settings_dialog.py
+++ b/src/gui/ui/dialogs/settings_dialog.py
@@ -13,6 +13,7 @@ from PyQt5.QtCore import Qt
 from src.gui.config.constants import Colors
 from src.gui.config.styles import StyleSheet
 from src.gui.ui.components.buttons import AppButton
+from src.gui.ui.components.icons import AppIcons
 from src.gui.core.file_manager import (
     DEFAULT_PROMPT,
     get_summary_prompt, set_summary_prompt,
@@ -40,7 +41,7 @@ class SettingsDialog(QDialog):
         layout.setContentsMargins(24, 20, 24, 20)
 
         # 제목
-        title = QLabel("⚙️ 설정")
+        title = AppIcons.label('settings', '설정', icon_size=18)
         title.setStyleSheet(StyleSheet.modal_title())
         layout.addWidget(title)
         layout.addWidget(self._make_divider())
@@ -59,7 +60,7 @@ class SettingsDialog(QDialog):
         self.setLayout(layout)
 
     def _build_prompt_section(self, layout: QVBoxLayout):
-        label = QLabel("📝 요약 프롬프트:")
+        label = AppIcons.label('prompt', '요약 프롬프트:')
         label.setStyleSheet(StyleSheet.label())
         layout.addWidget(label)
 
@@ -74,11 +75,12 @@ class SettingsDialog(QDialog):
         layout.addWidget(self._prompt_edit)
 
         reset_btn = AppButton("기본값 복원", "text")
+        reset_btn.setIcon(AppIcons.icon('reset'))
         reset_btn.clicked.connect(self._reset_prompt)
         layout.addWidget(reset_btn, alignment=Qt.AlignLeft)
 
     def _build_chrome_section(self, layout: QVBoxLayout):
-        label = QLabel("🌐 Chrome 브라우저 경로:")
+        label = AppIcons.label('chrome', 'Chrome 브라우저 경로:')
         label.setStyleSheet(StyleSheet.label())
         layout.addWidget(label)
 
@@ -94,7 +96,8 @@ class SettingsDialog(QDialog):
         path_row.addWidget(self._chrome_path_edit)
 
         browse_btn = AppButton("찾아보기...", "outline")
-        browse_btn.setFixedWidth(110)
+        browse_btn.setIcon(AppIcons.icon('browse'))
+        browse_btn.setFixedWidth(120)
         browse_btn.clicked.connect(self._browse_chrome)
         path_row.addWidget(browse_btn)
         layout.addLayout(path_row)
@@ -117,10 +120,12 @@ class SettingsDialog(QDialog):
         btn_layout.addStretch()
 
         cancel_btn = AppButton("취소", "outline")
+        cancel_btn.setIcon(AppIcons.icon('cancel'))
         cancel_btn.clicked.connect(self.reject)
         btn_layout.addWidget(cancel_btn)
 
         save_btn = AppButton("저장", "filled")
+        save_btn.setIcon(AppIcons.icon('save', color='white'))
         save_btn.clicked.connect(self._save_and_close)
         btn_layout.addWidget(save_btn)
 

--- a/src/gui/ui/dialogs/settings_dialog.py
+++ b/src/gui/ui/dialogs/settings_dialog.py
@@ -1,0 +1,168 @@
+"""
+설정 다이얼로그 - 요약 프롬프트, Chrome 경로 설정
+"""
+
+import os
+
+from PyQt5.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel,
+    QTextEdit, QLineEdit, QFileDialog, QMessageBox, QFrame
+)
+from PyQt5.QtCore import Qt
+
+from src.gui.config.constants import Colors
+from src.gui.config.styles import StyleSheet
+from src.gui.ui.components.buttons import AppButton
+from src.gui.core.file_manager import (
+    DEFAULT_PROMPT,
+    get_summary_prompt, set_summary_prompt,
+    get_chrome_path, set_chrome_path, detect_chrome_paths,
+)
+
+
+class SettingsDialog(QDialog):
+    """요약 프롬프트 및 Chrome 경로를 설정하는 다이얼로그"""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("설정")
+        self.setModal(True)
+        self.setMinimumWidth(500)
+        self.setStyleSheet(StyleSheet.modal_window())
+        self._setup_ui()
+        self._load_current_settings()
+
+    # ── UI 구성 ────────────────────────────────────────────────
+
+    def _setup_ui(self):
+        layout = QVBoxLayout()
+        layout.setSpacing(12)
+        layout.setContentsMargins(24, 20, 24, 20)
+
+        # 제목
+        title = QLabel("⚙️ 설정")
+        title.setStyleSheet(StyleSheet.modal_title())
+        layout.addWidget(title)
+        layout.addWidget(self._make_divider())
+
+        # 섹션 1: 요약 프롬프트
+        self._build_prompt_section(layout)
+        layout.addWidget(self._make_divider())
+
+        # 섹션 2: Chrome 경로
+        self._build_chrome_section(layout)
+        layout.addWidget(self._make_divider())
+
+        # 하단 버튼
+        self._build_button_section(layout)
+
+        self.setLayout(layout)
+
+    def _build_prompt_section(self, layout: QVBoxLayout):
+        label = QLabel("📝 요약 프롬프트:")
+        label.setStyleSheet(StyleSheet.label())
+        layout.addWidget(label)
+
+        desc = QLabel("AI 요약 시 사용되는 프롬프트를 수정할 수 있습니다.")
+        desc.setStyleSheet(f"color: {Colors.TEXT_LIGHT}; font-size: 11px;")
+        layout.addWidget(desc)
+
+        self._prompt_edit = QTextEdit()
+        self._prompt_edit.setStyleSheet(StyleSheet.multiline_input())
+        self._prompt_edit.setMinimumHeight(80)
+        self._prompt_edit.setMaximumHeight(150)
+        layout.addWidget(self._prompt_edit)
+
+        reset_btn = AppButton("기본값 복원", "text")
+        reset_btn.clicked.connect(self._reset_prompt)
+        layout.addWidget(reset_btn, alignment=Qt.AlignLeft)
+
+    def _build_chrome_section(self, layout: QVBoxLayout):
+        label = QLabel("🌐 Chrome 브라우저 경로:")
+        label.setStyleSheet(StyleSheet.label())
+        layout.addWidget(label)
+
+        desc = QLabel("LMS 영상 재생에 사용할 Chrome 실행 파일 경로입니다.")
+        desc.setStyleSheet(f"color: {Colors.TEXT_LIGHT}; font-size: 11px;")
+        layout.addWidget(desc)
+
+        # 경로 입력 + 찾아보기 버튼
+        path_row = QHBoxLayout()
+        self._chrome_path_edit = QLineEdit()
+        self._chrome_path_edit.setStyleSheet(StyleSheet.input_field())
+        self._chrome_path_edit.setPlaceholderText("Chrome 실행 파일 경로")
+        path_row.addWidget(self._chrome_path_edit)
+
+        browse_btn = AppButton("찾아보기...", "outline")
+        browse_btn.setFixedWidth(110)
+        browse_btn.clicked.connect(self._browse_chrome)
+        path_row.addWidget(browse_btn)
+        layout.addLayout(path_row)
+
+        # 자동 감지된 경로 표시
+        detected = detect_chrome_paths()
+        if detected:
+            hint = QLabel("자동 감지된 경로:")
+            hint.setStyleSheet(f"color: {Colors.TEXT_LIGHT}; font-size: 11px; margin-top: 4px;")
+            layout.addWidget(hint)
+            for path in detected:
+                path_btn = AppButton(path, "text")
+                path_btn.setStyleSheet(StyleSheet.path_suggestion_button())
+                path_btn.setCursor(Qt.PointingHandCursor)
+                path_btn.clicked.connect(lambda checked, p=path: self._chrome_path_edit.setText(p))
+                layout.addWidget(path_btn)
+
+    def _build_button_section(self, layout: QVBoxLayout):
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+
+        cancel_btn = AppButton("취소", "outline")
+        cancel_btn.clicked.connect(self.reject)
+        btn_layout.addWidget(cancel_btn)
+
+        save_btn = AppButton("저장", "filled")
+        save_btn.clicked.connect(self._save_and_close)
+        btn_layout.addWidget(save_btn)
+
+        layout.addLayout(btn_layout)
+
+    # ── 헬퍼 ──────────────────────────────────────────────────
+
+    def _make_divider(self) -> QFrame:
+        line = QFrame()
+        line.setFrameShape(QFrame.HLine)
+        line.setStyleSheet(StyleSheet.divider())
+        return line
+
+    def _load_current_settings(self):
+        self._prompt_edit.setPlainText(get_summary_prompt())
+        self._chrome_path_edit.setText(get_chrome_path())
+
+    def _reset_prompt(self):
+        self._prompt_edit.setPlainText(DEFAULT_PROMPT)
+
+    def _browse_chrome(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Chrome 실행 파일 선택", "", "모든 파일 (*)"
+        )
+        if path:
+            self._chrome_path_edit.setText(path)
+
+    def _save_and_close(self):
+        prompt = self._prompt_edit.toPlainText().strip()
+        chrome_path = self._chrome_path_edit.text().strip()
+
+        # 프롬프트 저장 (빈 값이면 기본값 사용)
+        set_summary_prompt(prompt if prompt else DEFAULT_PROMPT)
+
+        # Chrome 경로 저장 (경로가 있으면 존재 검증)
+        if chrome_path:
+            if not os.path.exists(chrome_path):
+                QMessageBox.warning(
+                    self, "경고",
+                    f"지정한 Chrome 경로가 존재하지 않습니다:\n{chrome_path}"
+                )
+                return
+            set_chrome_path(chrome_path)
+
+        self.accept()

--- a/src/gui/ui/windows/main_window.py
+++ b/src/gui/ui/windows/main_window.py
@@ -154,7 +154,7 @@ class MainWindow(QWidget):
         card.setStyleSheet(StyleSheet.card())
         card_layout = QVBoxLayout(card)
         card_layout.setContentsMargins(16, 14, 16, 14)
-        card_layout.setSpacing(2)
+        card_layout.setSpacing(4)
 
         # 입력 필드 생성
         for field_name, config in INPUT_FIELD_CONFIGS.items():
@@ -181,11 +181,16 @@ class MainWindow(QWidget):
         urls_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         urls_widget.setMinimumHeight(80)
 
+        # 체크박스/버튼 영역과 입력 필드 사이 간격
+        card_layout.addSpacing(8)
+
         # 옵션 체크박스
         self.save_video_checkbox = QCheckBox("처리 완료 후 원본 동영상 보관 (미선택 시 자동 삭제)")
         self.save_video_checkbox.setStyleSheet(StyleSheet.checkbox())
         self.save_video_checkbox.setChecked(False)
         card_layout.addWidget(self.save_video_checkbox)
+
+        card_layout.addSpacing(4)
 
         # 버튼 영역
         btn_layout = QHBoxLayout()

--- a/src/gui/ui/windows/main_window.py
+++ b/src/gui/ui/windows/main_window.py
@@ -17,7 +17,7 @@ from src.gui.config.constants import (
     APP_TITLE, APP_VERSION,
     WINDOW_WIDTH, WINDOW_HEIGHT,
     MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT,
-    Messages, EMOJI_PROCESSING
+    Messages,
 )
 from src.gui.config.styles import StyleSheet
 from src.gui.config.settings import INPUT_FIELD_CONFIGS
@@ -30,6 +30,7 @@ from src.gui.core.file_manager import (
 from src.gui.ui.components.input_field import InputField
 from src.gui.ui.components.log_area import LogArea
 from src.gui.ui.components.buttons import ProcessingButton, ClearButton, AppButton
+from src.gui.ui.components.icons import AppIcons
 from src.gui.ui.components.model_selector import ModelSelector
 from src.gui.ui.components.toast import ToastMessage
 from src.gui.ui.dialogs.progress_modal import ProcessingModal
@@ -97,19 +98,19 @@ class MainWindow(QWidget):
     def _create_header_section(self, layout: QVBoxLayout):
         header_row = QHBoxLayout()
 
-        title = QLabel(f"🎓 {APP_TITLE}")
-        title.setAlignment(Qt.AlignLeft)
+        title = AppIcons.label('graduation', APP_TITLE, icon_size=20)
         title.setStyleSheet(StyleSheet.title())
         header_row.addWidget(title, stretch=1)
 
-        settings_btn = AppButton("⚙️ 설정", "text")
+        settings_btn = AppButton("설정", "text")
+        settings_btn.setIcon(AppIcons.icon('settings'))
         settings_btn.setFixedWidth(80)
         settings_btn.clicked.connect(self._open_settings_dialog)
         header_row.addWidget(settings_btn)
 
         layout.addLayout(header_row)
 
-        desc = QLabel("📖 숭실대학교 LMS 강의 동영상을 다운로드하고 AI로 요약합니다.")
+        desc = QLabel("숭실대학교 LMS 강의 동영상을 다운로드하고 AI로 요약합니다.")
         desc.setAlignment(Qt.AlignCenter)
         desc.setStyleSheet(StyleSheet.subtitle())
         layout.addWidget(desc)
@@ -118,9 +119,9 @@ class MainWindow(QWidget):
         path_layout = QHBoxLayout()
         path_layout.setSpacing(6)
 
-        path_label = QLabel("📁 저장 경로:")
+        path_label = AppIcons.label('folder', '저장 경로:')
         path_label.setStyleSheet(StyleSheet.label())
-        path_label.setFixedWidth(72)
+        path_label.setFixedWidth(90)
         path_layout.addWidget(path_label)
 
         current_path = ensure_downloads_directory()
@@ -129,7 +130,8 @@ class MainWindow(QWidget):
         self.path_value_label.setWordWrap(True)
         path_layout.addWidget(self.path_value_label, stretch=1)
 
-        open_btn = AppButton("📂 열기", "outline")
+        open_btn = AppButton("열기", "outline")
+        open_btn.setIcon(AppIcons.icon('folder_open'))
         open_btn.setFixedWidth(90)
         open_btn.clicked.connect(self._open_in_finder)
         path_layout.addWidget(open_btn)
@@ -167,7 +169,7 @@ class MainWindow(QWidget):
 
             # API 키 필드 다음에 AI 모델 선택기 추가
             if field_name == 'api_key':
-                model_label = QLabel("🤖 AI 모델:")
+                model_label = AppIcons.label('robot', 'AI 모델:')
                 model_label.setStyleSheet(StyleSheet.label())
                 card_layout.addWidget(model_label)
 
@@ -180,7 +182,7 @@ class MainWindow(QWidget):
         urls_widget.setMinimumHeight(80)
 
         # 옵션 체크박스
-        self.save_video_checkbox = QCheckBox("📹 처리 완료 후 원본 동영상 보관 (미선택 시 자동 삭제)")
+        self.save_video_checkbox = QCheckBox("처리 완료 후 원본 동영상 보관 (미선택 시 자동 삭제)")
         self.save_video_checkbox.setStyleSheet(StyleSheet.checkbox())
         self.save_video_checkbox.setChecked(False)
         card_layout.addWidget(self.save_video_checkbox)
@@ -267,7 +269,8 @@ class MainWindow(QWidget):
             self.worker.request_cancel()
             self.log_area.append_message("⚠️ 작업 중지를 요청했습니다...")
             self.start_button.setEnabled(False)
-            self.start_button.setText(f"{EMOJI_PROCESSING} 중지 중...")
+            self.start_button.setText("중지 중...")
+            self.start_button.setIcon(AppIcons.icon('processing', color='white'))
 
     def _handle_clear_inputs(self):
         reply = QMessageBox.question(

--- a/src/gui/ui/windows/main_window.py
+++ b/src/gui/ui/windows/main_window.py
@@ -33,6 +33,7 @@ from src.gui.ui.components.buttons import ProcessingButton, ClearButton, AppButt
 from src.gui.ui.components.model_selector import ModelSelector
 from src.gui.ui.components.toast import ToastMessage
 from src.gui.ui.dialogs.progress_modal import ProcessingModal
+from src.gui.ui.dialogs.settings_dialog import SettingsDialog
 from src.gui.workers.processing_worker import ProcessingWorker
 
 
@@ -94,10 +95,19 @@ class MainWindow(QWidget):
         self.setLayout(main_layout)
 
     def _create_header_section(self, layout: QVBoxLayout):
+        header_row = QHBoxLayout()
+
         title = QLabel(f"🎓 {APP_TITLE}")
-        title.setAlignment(Qt.AlignCenter)
+        title.setAlignment(Qt.AlignLeft)
         title.setStyleSheet(StyleSheet.title())
-        layout.addWidget(title)
+        header_row.addWidget(title, stretch=1)
+
+        settings_btn = AppButton("⚙️ 설정", "text")
+        settings_btn.setFixedWidth(80)
+        settings_btn.clicked.connect(self._open_settings_dialog)
+        header_row.addWidget(settings_btn)
+
+        layout.addLayout(header_row)
 
         desc = QLabel("📖 숭실대학교 LMS 강의 동영상을 다운로드하고 AI로 요약합니다.")
         desc.setAlignment(Qt.AlignCenter)
@@ -219,6 +229,10 @@ class MainWindow(QWidget):
                 self.log_area.append_message(f"✅ 저장 경로 변경: {new_path}")
             except Exception as e:
                 QMessageBox.critical(self, "경로 변경 오류", f"저장 경로 변경 중 오류:\n{str(e)}")
+
+    def _open_settings_dialog(self):
+        dialog = SettingsDialog(self)
+        dialog.exec_()
 
     def _open_in_finder(self):
         path = ensure_downloads_directory()

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -9,7 +9,10 @@ from typing import Dict, List
 from PyQt5.QtCore import QThread, pyqtSignal
 
 from src.gui.config.constants import Messages
-from src.gui.core.file_manager import create_config_files, extract_urls_from_input, ensure_downloads_directory
+from src.gui.core.file_manager import (
+    create_config_files, extract_urls_from_input, ensure_downloads_directory,
+    get_summary_prompt, get_chrome_path,
+)
 from src.gui.core.module_loader import check_required_modules
 
 
@@ -34,6 +37,8 @@ class ProcessingWorker(QThread):
         self.modules = modules
         self.save_video_dir = save_video_dir
         self.model_name = model_name
+        self.summary_prompt = get_summary_prompt()
+        self.chrome_path = get_chrome_path()
         self._cancel_event = threading.Event()
 
     def request_cancel(self):
@@ -155,7 +160,10 @@ class ProcessingWorker(QThread):
                 mb_total = total / (1024 * 1024)
                 self._emit_log(f"   📊 다운로드 진행: {pct}% ({mb_down:.1f}/{mb_total:.1f} MB)")
 
-        video_pipeline = self.modules['VideoPipeline'](user_setting, progress_callback=on_progress)
+        video_pipeline = self.modules['VideoPipeline'](
+            user_setting, progress_callback=on_progress,
+            chrome_path=self.chrome_path,
+        )
         video_pipeline.downloads_dir = ensure_downloads_directory()
 
         self._check_cancelled()
@@ -221,7 +229,7 @@ class ProcessingWorker(QThread):
         """텍스트 요약"""
         self._emit_log(Messages.TEXT_SUMMARIZING)
 
-        summarize_pipeline = self.modules['SummarizePipeline'](self.model_name)
+        summarize_pipeline = self.modules['SummarizePipeline'](self.model_name, prompt=self.summary_prompt)
         summary_paths = []
 
         for i, text_path in enumerate(text_paths, 1):

--- a/src/summarize_pipeline/pipeline.py
+++ b/src/summarize_pipeline/pipeline.py
@@ -5,10 +5,14 @@ from pathlib import Path
 from src.summarize_pipeline.summarizer import summarize_text
 
 
+_DEFAULT_PROMPT = "다음 강의 내용을 한국어로 자세히 요약해주세요."
+
+
 class SummarizePipeline:
-    def __init__(self, model_name: str = "gemini-2.5-flash"):
+    def __init__(self, model_name: str = "gemini-2.5-flash", prompt: str = None):
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
         self.model_name = model_name
+        self.prompt = prompt or _DEFAULT_PROMPT
 
     def process(self, text_path: str) -> str:
         """텍스트 요약"""
@@ -18,7 +22,7 @@ class SummarizePipeline:
 
         print(f"[INFO] 요약 시작: {text_path}")
         start_time = time.time()
-        summary = summarize_text(text_path, "다음 강의 내용을 한국어로 자세히 요약해주세요.",
+        summary = summarize_text(text_path, self.prompt,
                                  model_name=self.model_name)
 
         end_time = time.time()

--- a/src/video_pipeline/pipeline.py
+++ b/src/video_pipeline/pipeline.py
@@ -18,21 +18,26 @@ def sanitize_dirname(name: str) -> str:
     return sanitized or 'untitled'
 
 
+_DEFAULT_CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+
 class VideoPipeline:
     def __init__(self, user_setting: UserSetting, extraction_timeout: float = 60,
-                 progress_callback: Optional[Callable[[int, int], None]] = None):
+                 progress_callback: Optional[Callable[[int, int], None]] = None,
+                 chrome_path: str = None):
         self.user_setting = user_setting
         self.user_id = user_setting.user_id
         self.password = user_setting.password
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
         self.extraction_timeout = extraction_timeout
         self.progress_callback = progress_callback
+        self.chrome_path = chrome_path or _DEFAULT_CHROME_PATH
 
     async def _setup_browser(self, playwright: Playwright) -> Tuple[Page, any]:
         """브라우저 설정 및 페이지 생성"""
         browser = await playwright.chromium.launch(
             headless=False,
-            executable_path="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            executable_path=self.chrome_path,
             args=[
                 "--disable-blink-features=AutomationControlled",
                 "--enable-proprietary-codecs",

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.10'" },
+    { name = "cuda-pathfinder", marker = "(python_full_version >= '3.10' and platform_machine != 'AMD64') or (python_full_version >= '3.10' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
@@ -663,7 +663,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "zipp", marker = "(python_full_version < '3.10' and platform_machine != 'AMD64') or (python_full_version < '3.10' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -821,6 +821,7 @@ dependencies = [
     { name = "pyqt5" },
     { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "qtawesome" },
     { name = "requests" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -835,6 +836,7 @@ requires-dist = [
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "pyqt5", specifier = ">=5.15.11" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "qtawesome", specifier = ">=1.4.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "torch", specifier = ">=2.7.0" },
 ]
@@ -1201,7 +1203,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1212,7 +1214,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -1239,9 +1241,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -1252,7 +1254,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'AMD64' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -1352,6 +1354,15 @@ dependencies = [
     { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'linux2')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz", hash = "sha256:37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96", size = 803191, upload-time = "2025-06-26T01:06:13.34Z" }
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
 
 [[package]]
 name = "playwright"
@@ -1725,6 +1736,30 @@ wheels = [
 ]
 
 [[package]]
+name = "qtawesome"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "qtpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/b8/7bd7527025a6f485e8f40b9f85b813ca3420ba940a91ac41bd1eb5904cda/qtawesome-1.4.1.tar.gz", hash = "sha256:d6c5aa545b614fc562769e9eeadf18530e08b8eebe28af4ab5d38131194c9c7b", size = 2614043, upload-time = "2026-01-23T20:45:18.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ef/b7c8c38d1717e2fcb777678ed11568b31062e34550e23297cc32e9e1105e/qtawesome-1.4.1-py3-none-any.whl", hash = "sha256:6a45f0ec214e0cd7c9c867772ec596799dcd5fae00a4b17717ff0d95d2e3fb64", size = 2593544, upload-time = "2026-01-23T20:45:16.93Z" },
+]
+
+[[package]]
+name = "qtpy"
+version = "2.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/76/37c0ccd5ab968a6a438f9c623aeecc84c202ab2fabc6a8fd927580c15b5a/QtPy-2.4.3-py3-none-any.whl", hash = "sha256:72095afe13673e017946cc258b8d5da43314197b741ed2890e563cf384b51aa1", size = 95045, upload-time = "2025-02-11T15:09:24.162Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.1.15"
 source = { registry = "https://pypi.org/simple" }
@@ -2092,8 +2127,8 @@ resolution-markers = [
     "(python_full_version < '3.10' and platform_machine != 'AMD64') or (python_full_version < '3.10' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
-    { name = "setuptools", marker = "python_full_version < '3.10'" },
+    { name = "importlib-metadata", marker = "(python_full_version < '3.10' and platform_machine != 'AMD64') or (python_full_version < '3.10' and sys_platform != 'win32')" },
+    { name = "setuptools", marker = "(python_full_version < '3.10' and platform_machine != 'AMD64') or (python_full_version < '3.10' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },


### PR DESCRIPTION
## Summary
- 설정 다이얼로그(⚙️ 설정 버튼) 추가: 요약 프롬프트 편집, Chrome 경로 설정
- Chrome 경로를 Mac 하드코딩에서 OS별 자동 감지 + 사용자 설정으로 변경
- 모든 설정(프롬프트, Chrome 경로, 다운로드 경로 등)을 settings.json에 통합

## 주요 변경사항

### 설정 다이얼로그 (`settings_dialog.py` 신규)
- **요약 프롬프트**: QTextEdit로 확인/수정, "기본값 복원" 버튼
- **Chrome 경로**: OS별 자동 감지된 경로 클릭 선택 + 찾아보기 버튼
- 저장 시 Chrome 경로 존재 검증

### 설정 인프라 (`file_manager.py`)
- `get_summary_prompt()` / `set_summary_prompt()`: 프롬프트 저장/로드
- `detect_chrome_paths()`: macOS, Windows, Linux 자동 감지
- `get_chrome_path()` / `set_chrome_path()`: Chrome 경로 저장/로드

### 파이프라인 파라미터화
- `SummarizePipeline`: `prompt` 파라미터 추가 (하드코딩 제거)
- `VideoPipeline`: `chrome_path` 파라미터 추가 (하드코딩 제거)
- `ProcessingWorker`: 설정에서 읽어 파이프라인에 전달

## Test plan
- [x] 헤더 "⚙️ 설정" 버튼 클릭 → 다이얼로그 열림
- [x] 프롬프트 수정 후 저장 → 요약 시 변경된 프롬프트 사용 확인
- [x] "기본값 복원" 클릭 → 기본 프롬프트 복원
- [x] Chrome 경로 자동 감지 목록 표시 확인
- [x] 찾아보기 → 파일 선택 다이얼로그
- [x] 앱 재시작 → 저장된 설정 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)