### PR TITLE
feat: Canvas LMS 강의 목록 불러오기 및 다운로드 안정성 개선

### DIFF
--- a/src/gui/config/course_models.py
+++ b/src/gui/config/course_models.py
@@ -84,6 +84,7 @@ class LectureItem:
     attendance: str = "none"
     completion: str = "incomplete"
     content_type_label: str = ""
+    is_upcoming: bool = False
 
     @property
     def is_video(self) -> bool:

--- a/src/gui/config/course_models.py
+++ b/src/gui/config/course_models.py
@@ -1,0 +1,124 @@
+"""
+Canvas LMS 과목/강의 데이터 모델
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+
+_BASE_URL = "https://canvas.ssu.ac.kr"
+
+
+class LectureType(Enum):
+    """강의 아이템 타입 (xnmb-module_item-icon 클래스)"""
+    MOVIE = "movie"
+    READYSTREAM = "readystream"
+    SCREENLECTURE = "screenlecture"
+    EVERLEC = "everlec"
+    ZOOM = "zoom"
+    MP4 = "mp4"
+    ASSIGNMENT = "assignment"
+    WIKI_PAGE = "wiki_page"
+    QUIZ = "quiz"
+    DISCUSSION = "discussion"
+    FILE = "file"
+    OTHER = "other"
+
+
+VIDEO_LECTURE_TYPES = {
+    LectureType.MOVIE,
+    LectureType.READYSTREAM,
+    LectureType.SCREENLECTURE,
+    LectureType.EVERLEC,
+    LectureType.MP4,
+}
+
+
+@dataclass
+class Course:
+    """대시보드에서 추출한 수강 과목 정보"""
+    id: str
+    long_name: str
+    href: str
+    term: str
+    is_favorited: bool = False
+
+    @property
+    def full_url(self) -> str:
+        return f"{_BASE_URL}{self.href}"
+
+    @property
+    def lectures_url(self) -> str:
+        return f"{_BASE_URL}/courses/{self.id}/external_tools/71"
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "long_name": self.long_name,
+            "href": self.href,
+            "term": self.term,
+            "is_favorited": self.is_favorited,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Course":
+        return cls(
+            id=data["id"],
+            long_name=data["long_name"],
+            href=data["href"],
+            term=data.get("term", ""),
+            is_favorited=data.get("is_favorited", False),
+        )
+
+
+@dataclass
+class LectureItem:
+    """주차별 강의 내 개별 아이템"""
+    title: str
+    item_url: str
+    lecture_type: LectureType
+    week_label: str = ""
+    lesson_label: str = ""
+    duration: Optional[str] = None
+    attendance: str = "none"
+    completion: str = "incomplete"
+    content_type_label: str = ""
+
+    @property
+    def is_video(self) -> bool:
+        return self.lecture_type in VIDEO_LECTURE_TYPES
+
+    @property
+    def full_url(self) -> str:
+        if self.item_url.startswith("http"):
+            return self.item_url
+        return f"{_BASE_URL}{self.item_url}"
+
+
+@dataclass
+class Week:
+    """주차 모듈 컨테이너"""
+    title: str
+    week_number: int
+    lectures: List[LectureItem] = field(default_factory=list)
+
+    @property
+    def video_lectures(self) -> List[LectureItem]:
+        return [l for l in self.lectures if l.is_video]
+
+
+@dataclass
+class CourseDetail:
+    """과목의 전체 주차별 강의 상세"""
+    course: Course
+    course_name: str
+    professors: str
+    weeks: List[Week] = field(default_factory=list)
+
+    @property
+    def all_video_lectures(self) -> List[LectureItem]:
+        result = []
+        for week in self.weeks:
+            result.extend(week.video_lectures)
+        return result

--- a/src/gui/config/styles.py
+++ b/src/gui/config/styles.py
@@ -421,3 +421,67 @@ class StyleSheet:
                 text-decoration: underline;
             }}
         """
+
+    # ── 강의 목록 다이얼로그 ────────────────────────────────────
+
+    @staticmethod
+    def course_list_widget() -> str:
+        return f"""
+            QListWidget {{
+                border: 1px solid {Colors.BORDER};
+                border-radius: 6px;
+                background-color: {Colors.WHITE};
+                padding: 4px;
+                outline: none;
+            }}
+            QListWidget::item {{
+                padding: 10px 12px;
+                border-radius: 4px;
+            }}
+            QListWidget::item:hover {{
+                background-color: #E3F2FD;
+            }}
+            QListWidget::item:selected {{
+                background-color: {Colors.PRIMARY};
+                color: white;
+            }}
+        """
+
+    @staticmethod
+    def lecture_tree_widget() -> str:
+        return f"""
+            QTreeWidget {{
+                border: 1px solid {Colors.BORDER};
+                border-radius: 6px;
+                background-color: {Colors.WHITE};
+                padding: 4px;
+                outline: none;
+            }}
+            QTreeWidget::item {{
+                padding: 4px 8px;
+            }}
+            QTreeWidget::item:hover {{
+                background-color: #E3F2FD;
+            }}
+            QTreeWidget::branch {{
+                background: transparent;
+            }}
+            QTreeWidget::indicator {{
+                width: 16px;
+                height: 16px;
+            }}
+            QTreeWidget::indicator:unchecked {{
+                border: 1.5px solid {Colors.BORDER};
+                border-radius: 3px;
+                background-color: {Colors.WHITE};
+            }}
+            QTreeWidget::indicator:checked {{
+                background-color: {Colors.PRIMARY};
+                border-color: {Colors.PRIMARY};
+                border-radius: 3px;
+            }}
+        """
+
+    @staticmethod
+    def status_label() -> str:
+        return f"color: {Colors.TEXT_LIGHT}; font-size: 12px;"

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -205,3 +205,39 @@ def set_chrome_path(path: str) -> None:
     settings = load_settings()
     settings["chrome_path"] = path
     save_settings(settings)
+
+
+# ── 과목 캐시 ─────────────────────────────────────────────
+
+def save_course_cache(courses_data: list) -> None:
+    """과목 목록 캐시를 settings.json에 저장"""
+    from datetime import datetime
+    settings = load_settings()
+    settings["course_cache"] = {
+        "courses": courses_data,
+        "cached_at": datetime.now().isoformat(),
+    }
+    save_settings(settings)
+
+
+def load_course_cache(max_age_hours: int = 24) -> list:
+    """캐시된 과목 목록 반환. 만료 시 빈 리스트."""
+    from datetime import datetime
+    settings = load_settings()
+    cache = settings.get("course_cache")
+    if not cache:
+        return []
+    try:
+        cached_at = datetime.fromisoformat(cache["cached_at"])
+        if (datetime.now() - cached_at).total_seconds() > max_age_hours * 3600:
+            return []
+    except (KeyError, ValueError):
+        return []
+    return cache.get("courses", [])
+
+
+def clear_course_cache() -> None:
+    """과목 목록 캐시 삭제"""
+    settings = load_settings()
+    settings.pop("course_cache", None)
+    save_settings(settings)

--- a/src/gui/ui/components/icons.py
+++ b/src/gui/ui/components/icons.py
@@ -59,6 +59,18 @@ _ICON_MAP = {
     'chevron_down': 'mdi6.chevron-down',
     'chevron_up': 'mdi6.chevron-up',
 
+    # 강의 목록
+    'refresh': 'mdi6.refresh',
+    'back': 'mdi6.arrow-left',
+    'select_all': 'mdi6.checkbox-multiple-marked',
+    'deselect_all': 'mdi6.checkbox-multiple-blank-outline',
+    'star': 'mdi6.star',
+    'star_outline': 'mdi6.star-outline',
+    'list': 'mdi6.format-list-bulleted',
+    'assignment': 'mdi6.clipboard-text',
+    'wiki': 'mdi6.note-text',
+    'quiz': 'mdi6.help-circle',
+
     # 기타
     'warning': 'mdi6.alert-outline',
     'processing': 'mdi6.timer-sand',

--- a/src/gui/ui/dialogs/course_list_dialog.py
+++ b/src/gui/ui/dialogs/course_list_dialog.py
@@ -8,8 +8,10 @@ from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel,
     QListWidget, QListWidgetItem, QTreeWidget, QTreeWidgetItem,
     QCheckBox, QStackedWidget, QWidget, QFrame, QSizePolicy,
+    QProgressBar,
 )
 from PyQt5.QtCore import Qt, QSize
+from PyQt5.QtGui import QColor
 
 from src.gui.config.constants import Colors
 from src.gui.config.styles import StyleSheet
@@ -95,6 +97,15 @@ class CourseListDialog(QDialog):
         desc.setStyleSheet(f"color: {Colors.TEXT_LIGHT}; font-size: 12px;")
         layout.addWidget(desc)
 
+        # 로딩 표시
+        self._course_loading_bar = QProgressBar()
+        self._course_loading_bar.setRange(0, 0)  # indeterminate
+        self._course_loading_bar.setFixedHeight(4)
+        self._course_loading_bar.setTextVisible(False)
+        self._course_loading_bar.setStyleSheet(StyleSheet.progress_bar())
+        self._course_loading_bar.setVisible(False)
+        layout.addWidget(self._course_loading_bar)
+
         # 과목 리스트
         self._course_list = QListWidget()
         self._course_list.setStyleSheet(StyleSheet.course_list_widget())
@@ -167,6 +178,15 @@ class CourseListDialog(QDialog):
 
         layout.addLayout(filter_row)
 
+        # 로딩 표시
+        self._lecture_loading_bar = QProgressBar()
+        self._lecture_loading_bar.setRange(0, 0)  # indeterminate
+        self._lecture_loading_bar.setFixedHeight(4)
+        self._lecture_loading_bar.setTextVisible(False)
+        self._lecture_loading_bar.setStyleSheet(StyleSheet.progress_bar())
+        self._lecture_loading_bar.setVisible(False)
+        layout.addWidget(self._lecture_loading_bar)
+
         # 강의 트리
         self._lecture_tree = QTreeWidget()
         self._lecture_tree.setHeaderHidden(True)
@@ -214,6 +234,7 @@ class CourseListDialog(QDialog):
         self._cleanup_worker()
         self._course_list.clear()
         self._course_status_label.setText("과목 목록을 불러오는 중... (브라우저가 열립니다)")
+        self._course_loading_bar.setVisible(True)
         self._set_course_page_enabled(False)
 
         self._worker = CourseListWorker(self._username, self._password)
@@ -224,6 +245,7 @@ class CourseListDialog(QDialog):
 
     def _on_courses_loaded(self, courses: List[Course]):
         self._courses = courses
+        self._course_loading_bar.setVisible(False)
         # 캐시 저장
         save_course_cache([c.to_dict() for c in courses])
         self._populate_course_list()
@@ -260,6 +282,7 @@ class CourseListDialog(QDialog):
 
         self._lecture_tree.clear()
         self._lecture_status_label.setText("강의 목록을 불러오는 중... (브라우저가 열립니다)")
+        self._lecture_loading_bar.setVisible(True)
         self._confirm_btn.setEnabled(False)
 
         self._worker = CourseListWorker(
@@ -272,6 +295,7 @@ class CourseListDialog(QDialog):
 
     def _on_lectures_loaded(self, detail: CourseDetail):
         self._course_detail = detail
+        self._lecture_loading_bar.setVisible(False)
         self._populate_lecture_tree(detail)
 
     def _populate_lecture_tree(self, detail: CourseDetail):
@@ -323,14 +347,21 @@ class CourseListDialog(QDialog):
                 if att_text:
                     parts.append(f"[{att_text}]")
 
+                # 예정 표시
+                if lecture.is_upcoming:
+                    parts.append("[예정]")
+
                 child.setText(0, "  ".join(parts))
 
                 # 아이콘
                 icon_name = _TYPE_ICON_MAP.get(lecture.lecture_type, "list")
                 child.setIcon(0, AppIcons.icon(icon_name))
 
-                # 체크박스 (영상만 선택 가능)
-                if lecture.is_video and lecture.item_url:
+                # 예정 항목: 비활성화 (회색 텍스트, 체크 불가)
+                if lecture.is_upcoming:
+                    child.setFlags(child.flags() & ~(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled))
+                    child.setForeground(0, QColor(Colors.TEXT_LIGHT))
+                elif lecture.is_video and lecture.item_url:
                     child.setFlags(child.flags() | Qt.ItemIsUserCheckable)
                     child.setCheckState(0, Qt.Unchecked)
                 else:
@@ -415,6 +446,8 @@ class CourseListDialog(QDialog):
     # ── 에러/완료 처리 ─────────────────────────────────────────
 
     def _on_load_error(self, error_msg: str):
+        self._course_loading_bar.setVisible(False)
+        self._lecture_loading_bar.setVisible(False)
         if self._stack.currentIndex() == 0:
             self._course_status_label.setText(f"오류: {error_msg}")
             self._set_course_page_enabled(True)
@@ -422,6 +455,8 @@ class CourseListDialog(QDialog):
             self._lecture_status_label.setText(f"오류: {error_msg}")
 
     def _on_worker_finished(self):
+        self._course_loading_bar.setVisible(False)
+        self._lecture_loading_bar.setVisible(False)
         if self._stack.currentIndex() == 0:
             self._set_course_page_enabled(True)
 

--- a/src/gui/ui/dialogs/course_list_dialog.py
+++ b/src/gui/ui/dialogs/course_list_dialog.py
@@ -1,0 +1,447 @@
+"""
+강의 목록 다이얼로그 - 과목 선택 → 강의 선택 2단계 UI
+"""
+
+from typing import List, Optional
+
+from PyQt5.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel,
+    QListWidget, QListWidgetItem, QTreeWidget, QTreeWidgetItem,
+    QCheckBox, QStackedWidget, QWidget, QFrame, QSizePolicy,
+)
+from PyQt5.QtCore import Qt, QSize
+
+from src.gui.config.constants import Colors
+from src.gui.config.styles import StyleSheet
+from src.gui.config.course_models import (
+    Course, CourseDetail, LectureItem, Week, LectureType, VIDEO_LECTURE_TYPES,
+)
+from src.gui.ui.components.buttons import AppButton
+from src.gui.ui.components.icons import AppIcons
+from src.gui.core.file_manager import (
+    save_course_cache, load_course_cache,
+)
+from src.gui.workers.course_list_worker import CourseListWorker
+
+
+# LectureType → 아이콘 이름 매핑
+_TYPE_ICON_MAP = {
+    LectureType.MOVIE: "movie",
+    LectureType.READYSTREAM: "movie",
+    LectureType.SCREENLECTURE: "movie",
+    LectureType.EVERLEC: "movie",
+    LectureType.MP4: "movie",
+    LectureType.ZOOM: "video",
+    LectureType.ASSIGNMENT: "assignment",
+    LectureType.WIKI_PAGE: "wiki",
+    LectureType.QUIZ: "quiz",
+    LectureType.DISCUSSION: "log",
+    LectureType.FILE: "folder",
+    LectureType.OTHER: "list",
+}
+
+
+class CourseListDialog(QDialog):
+    """과목 선택 → 강의 선택 2단계 다이얼로그"""
+
+    def __init__(self, parent=None, username: str = "", password: str = ""):
+        super().__init__(parent)
+        self._username = username
+        self._password = password
+        self._courses: List[Course] = []
+        self._course_detail: Optional[CourseDetail] = None
+        self._selected_urls: List[str] = []
+        self._worker: Optional[CourseListWorker] = None
+
+        self.setWindowTitle("강의 목록")
+        self.setModal(True)
+        self.setMinimumSize(560, 480)
+        self.resize(600, 560)
+        self.setStyleSheet(StyleSheet.modal_window())
+
+        self._setup_ui()
+        self._try_load_cached_courses()
+
+    # ── UI 구성 ────────────────────────────────────────────────
+
+    def _setup_ui(self):
+        main_layout = QVBoxLayout()
+        main_layout.setSpacing(0)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._stack = QStackedWidget()
+        self._stack.addWidget(self._build_course_page())
+        self._stack.addWidget(self._build_lecture_page())
+
+        main_layout.addWidget(self._stack)
+        self.setLayout(main_layout)
+
+    # ── Phase 1: 과목 선택 ──────────────────────────────────────
+
+    def _build_course_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setSpacing(10)
+        layout.setContentsMargins(24, 20, 24, 20)
+
+        # 제목
+        title = AppIcons.label('graduation', '강의 목록', icon_size=18)
+        title.setStyleSheet(StyleSheet.modal_title())
+        layout.addWidget(title)
+        layout.addWidget(self._make_divider())
+
+        # 설명
+        desc = QLabel("과목을 더블클릭하여 주차별 강의 목록을 확인하세요.")
+        desc.setStyleSheet(f"color: {Colors.TEXT_LIGHT}; font-size: 12px;")
+        layout.addWidget(desc)
+
+        # 과목 리스트
+        self._course_list = QListWidget()
+        self._course_list.setStyleSheet(StyleSheet.course_list_widget())
+        self._course_list.setIconSize(QSize(18, 18))
+        self._course_list.itemDoubleClicked.connect(self._on_course_double_clicked)
+        layout.addWidget(self._course_list, stretch=1)
+
+        # 상태 바 + 버튼
+        bottom_row = QHBoxLayout()
+
+        self._course_status_label = QLabel()
+        self._course_status_label.setStyleSheet(StyleSheet.status_label())
+        bottom_row.addWidget(self._course_status_label)
+
+        bottom_row.addStretch()
+
+        refresh_btn = AppButton("새로고침", "text")
+        refresh_btn.setIcon(AppIcons.icon('refresh'))
+        refresh_btn.clicked.connect(self._start_loading_courses)
+        bottom_row.addWidget(refresh_btn)
+
+        close_btn = AppButton("닫기", "outline")
+        close_btn.setIcon(AppIcons.icon('cancel'))
+        close_btn.clicked.connect(self.reject)
+        bottom_row.addWidget(close_btn)
+
+        layout.addLayout(bottom_row)
+        return page
+
+    # ── Phase 2: 강의 선택 ──────────────────────────────────────
+
+    def _build_lecture_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setSpacing(10)
+        layout.setContentsMargins(24, 20, 24, 20)
+
+        # 제목 + 뒤로가기
+        self._lecture_title = AppIcons.label('book', '강의 선택', icon_size=18)
+        self._lecture_title.setStyleSheet(StyleSheet.modal_title())
+        layout.addWidget(self._lecture_title)
+
+        back_btn = AppButton("< 과목 목록으로", "text")
+        back_btn.setIcon(AppIcons.icon('back'))
+        back_btn.clicked.connect(self._go_back_to_courses)
+        layout.addWidget(back_btn, alignment=Qt.AlignLeft)
+
+        layout.addWidget(self._make_divider())
+
+        # 필터 + 선택 버튼
+        filter_row = QHBoxLayout()
+
+        self._video_only_checkbox = QCheckBox("동영상 강의만 표시")
+        self._video_only_checkbox.setStyleSheet(StyleSheet.checkbox())
+        self._video_only_checkbox.setChecked(True)
+        self._video_only_checkbox.stateChanged.connect(self._apply_video_filter)
+        filter_row.addWidget(self._video_only_checkbox)
+
+        filter_row.addStretch()
+
+        select_all_btn = AppButton("전체 선택", "text")
+        select_all_btn.setIcon(AppIcons.icon('select_all'))
+        select_all_btn.clicked.connect(self._select_all)
+        filter_row.addWidget(select_all_btn)
+
+        deselect_all_btn = AppButton("전체 해제", "text")
+        deselect_all_btn.setIcon(AppIcons.icon('deselect_all'))
+        deselect_all_btn.clicked.connect(self._deselect_all)
+        filter_row.addWidget(deselect_all_btn)
+
+        layout.addLayout(filter_row)
+
+        # 강의 트리
+        self._lecture_tree = QTreeWidget()
+        self._lecture_tree.setHeaderHidden(True)
+        self._lecture_tree.setStyleSheet(StyleSheet.lecture_tree_widget())
+        self._lecture_tree.setIconSize(QSize(16, 16))
+        self._lecture_tree.itemChanged.connect(self._on_tree_item_changed)
+        layout.addWidget(self._lecture_tree, stretch=1)
+
+        # 상태 바 + 확인 버튼
+        bottom_row = QHBoxLayout()
+
+        self._lecture_status_label = QLabel()
+        self._lecture_status_label.setStyleSheet(StyleSheet.status_label())
+        bottom_row.addWidget(self._lecture_status_label)
+
+        bottom_row.addStretch()
+
+        cancel_btn = AppButton("취소", "outline")
+        cancel_btn.setIcon(AppIcons.icon('cancel'))
+        cancel_btn.clicked.connect(self.reject)
+        bottom_row.addWidget(cancel_btn)
+
+        self._confirm_btn = AppButton("선택한 강의 추가", "filled")
+        self._confirm_btn.setIcon(AppIcons.icon('start', color='white'))
+        self._confirm_btn.clicked.connect(self._confirm_selection)
+        self._confirm_btn.setEnabled(False)
+        bottom_row.addWidget(self._confirm_btn)
+
+        layout.addLayout(bottom_row)
+        return page
+
+    # ── 과목 로딩 ──────────────────────────────────────────────
+
+    def _try_load_cached_courses(self):
+        """캐시에서 과목 목록 로드 시도. 없으면 서버에서 로드."""
+        cached = load_course_cache()
+        if cached:
+            self._courses = [Course.from_dict(c) for c in cached]
+            self._populate_course_list()
+        else:
+            self._start_loading_courses()
+
+    def _start_loading_courses(self):
+        """서버에서 과목 목록 로드"""
+        self._cleanup_worker()
+        self._course_list.clear()
+        self._course_status_label.setText("과목 목록을 불러오는 중... (브라우저가 열립니다)")
+        self._set_course_page_enabled(False)
+
+        self._worker = CourseListWorker(self._username, self._password)
+        self._worker.courses_loaded.connect(self._on_courses_loaded)
+        self._worker.error_occurred.connect(self._on_load_error)
+        self._worker.finished_signal.connect(self._on_worker_finished)
+        self._worker.start()
+
+    def _on_courses_loaded(self, courses: List[Course]):
+        self._courses = courses
+        # 캐시 저장
+        save_course_cache([c.to_dict() for c in courses])
+        self._populate_course_list()
+
+    def _populate_course_list(self):
+        self._course_list.clear()
+        for course in self._courses:
+            icon_name = "star" if course.is_favorited else "star_outline"
+            text = f"{course.long_name}"
+            if course.term:
+                text += f"  ({course.term})"
+
+            item = QListWidgetItem(text)
+            item.setIcon(AppIcons.icon(icon_name))
+            item.setData(Qt.UserRole, course)
+            self._course_list.addItem(item)
+
+        self._course_status_label.setText(f"{len(self._courses)}개 과목")
+        self._set_course_page_enabled(True)
+
+    def _on_course_double_clicked(self, item: QListWidgetItem):
+        course = item.data(Qt.UserRole)
+        if course:
+            self._start_loading_lectures(course)
+
+    # ── 강의 로딩 ──────────────────────────────────────────────
+
+    def _start_loading_lectures(self, course: Course):
+        """과목의 주차별 강의 목록 로드"""
+        self._cleanup_worker()
+        self._stack.setCurrentIndex(1)
+        self._lecture_title.setStyleSheet(StyleSheet.modal_title())
+        self.setWindowTitle(f"강의 목록 - {course.long_name}")
+
+        self._lecture_tree.clear()
+        self._lecture_status_label.setText("강의 목록을 불러오는 중... (브라우저가 열립니다)")
+        self._confirm_btn.setEnabled(False)
+
+        self._worker = CourseListWorker(
+            self._username, self._password, course=course
+        )
+        self._worker.lectures_loaded.connect(self._on_lectures_loaded)
+        self._worker.error_occurred.connect(self._on_load_error)
+        self._worker.finished_signal.connect(self._on_worker_finished)
+        self._worker.start()
+
+    def _on_lectures_loaded(self, detail: CourseDetail):
+        self._course_detail = detail
+        self._populate_lecture_tree(detail)
+
+    def _populate_lecture_tree(self, detail: CourseDetail):
+        self._lecture_tree.blockSignals(True)
+        self._lecture_tree.clear()
+
+        video_only = self._video_only_checkbox.isChecked()
+
+        for week in detail.weeks:
+            lectures_to_show = week.lectures
+            if video_only:
+                lectures_to_show = week.video_lectures
+
+            if not lectures_to_show:
+                continue
+
+            # 주차 노드
+            week_item = QTreeWidgetItem(self._lecture_tree)
+            week_item.setText(0, week.title)
+            week_item.setFlags(
+                week_item.flags() | Qt.ItemIsAutoTristate | Qt.ItemIsUserCheckable
+            )
+            week_item.setCheckState(0, Qt.Unchecked)
+
+            # 볼드 폰트
+            font = week_item.font(0)
+            font.setBold(True)
+            week_item.setFont(0, font)
+
+            # 강의 아이템 노드
+            for lecture in lectures_to_show:
+                child = QTreeWidgetItem(week_item)
+
+                # 텍스트: 차시 + 제목 + 길이
+                parts = []
+                if lecture.lesson_label:
+                    parts.append(lecture.lesson_label)
+                parts.append(lecture.title)
+                if lecture.duration:
+                    parts.append(f"({lecture.duration})")
+
+                # 출석 상태
+                att_map = {
+                    "attendance": "출석",
+                    "late": "지각",
+                    "absent": "결석",
+                }
+                att_text = att_map.get(lecture.attendance, "")
+                if att_text:
+                    parts.append(f"[{att_text}]")
+
+                child.setText(0, "  ".join(parts))
+
+                # 아이콘
+                icon_name = _TYPE_ICON_MAP.get(lecture.lecture_type, "list")
+                child.setIcon(0, AppIcons.icon(icon_name))
+
+                # 체크박스 (영상만 선택 가능)
+                if lecture.is_video and lecture.item_url:
+                    child.setFlags(child.flags() | Qt.ItemIsUserCheckable)
+                    child.setCheckState(0, Qt.Unchecked)
+                else:
+                    child.setFlags(child.flags() & ~Qt.ItemIsUserCheckable)
+
+                child.setData(0, Qt.UserRole, lecture)
+
+            week_item.setExpanded(True)
+
+        self._lecture_tree.blockSignals(False)
+        self._update_selection_count()
+
+    # ── 필터/선택 ──────────────────────────────────────────────
+
+    def _apply_video_filter(self):
+        if self._course_detail:
+            self._populate_lecture_tree(self._course_detail)
+
+    def _select_all(self):
+        self._lecture_tree.blockSignals(True)
+        root = self._lecture_tree.invisibleRootItem()
+        for i in range(root.childCount()):
+            week_item = root.child(i)
+            week_item.setCheckState(0, Qt.Checked)
+        self._lecture_tree.blockSignals(False)
+        self._update_selection_count()
+
+    def _deselect_all(self):
+        self._lecture_tree.blockSignals(True)
+        root = self._lecture_tree.invisibleRootItem()
+        for i in range(root.childCount()):
+            week_item = root.child(i)
+            week_item.setCheckState(0, Qt.Unchecked)
+        self._lecture_tree.blockSignals(False)
+        self._update_selection_count()
+
+    def _on_tree_item_changed(self, item: QTreeWidgetItem, column: int):
+        self._update_selection_count()
+
+    def _update_selection_count(self):
+        selected = self._get_checked_lectures()
+        total_videos = 0
+        if self._course_detail:
+            total_videos = len(self._course_detail.all_video_lectures)
+
+        count = len(selected)
+        self._lecture_status_label.setText(
+            f"{total_videos}개 동영상 중 {count}개 선택"
+        )
+        self._confirm_btn.setEnabled(count > 0)
+        self._confirm_btn.setText(f"선택한 강의 추가 ({count})")
+
+    def _get_checked_lectures(self) -> List[LectureItem]:
+        """체크된 강의 아이템 목록 반환"""
+        checked = []
+        root = self._lecture_tree.invisibleRootItem()
+        for i in range(root.childCount()):
+            week_item = root.child(i)
+            for j in range(week_item.childCount()):
+                child = week_item.child(j)
+                if child.checkState(0) == Qt.Checked:
+                    lecture = child.data(0, Qt.UserRole)
+                    if lecture and lecture.item_url:
+                        checked.append(lecture)
+        return checked
+
+    # ── 네비게이션 ─────────────────────────────────────────────
+
+    def _go_back_to_courses(self):
+        self._cleanup_worker()
+        self._stack.setCurrentIndex(0)
+        self.setWindowTitle("강의 목록")
+
+    def _confirm_selection(self):
+        selected = self._get_checked_lectures()
+        self._selected_urls = [l.full_url for l in selected]
+        self.accept()
+
+    def get_selected_urls(self) -> List[str]:
+        return self._selected_urls
+
+    # ── 에러/완료 처리 ─────────────────────────────────────────
+
+    def _on_load_error(self, error_msg: str):
+        if self._stack.currentIndex() == 0:
+            self._course_status_label.setText(f"오류: {error_msg}")
+            self._set_course_page_enabled(True)
+        else:
+            self._lecture_status_label.setText(f"오류: {error_msg}")
+
+    def _on_worker_finished(self):
+        if self._stack.currentIndex() == 0:
+            self._set_course_page_enabled(True)
+
+    # ── 유틸리티 ───────────────────────────────────────────────
+
+    def _make_divider(self) -> QFrame:
+        line = QFrame()
+        line.setFrameShape(QFrame.HLine)
+        line.setStyleSheet(StyleSheet.divider())
+        return line
+
+    def _set_course_page_enabled(self, enabled: bool):
+        self._course_list.setEnabled(enabled)
+
+    def _cleanup_worker(self):
+        if self._worker and self._worker.isRunning():
+            self._worker.request_cancel()
+            self._worker.wait(3000)
+        self._worker = None
+
+    def closeEvent(self, event):
+        self._cleanup_worker()
+        event.accept()

--- a/src/gui/ui/windows/main_window.py
+++ b/src/gui/ui/windows/main_window.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QMessageBox,
-    QFileDialog, QCheckBox, QSplitter,
+    QDialog, QFileDialog, QCheckBox, QSplitter,
     QScrollArea, QFrame, QSizePolicy
 )
 from PyQt5.QtCore import Qt
@@ -35,6 +35,7 @@ from src.gui.ui.components.model_selector import ModelSelector
 from src.gui.ui.components.toast import ToastMessage
 from src.gui.ui.dialogs.progress_modal import ProcessingModal
 from src.gui.ui.dialogs.settings_dialog import SettingsDialog
+from src.gui.ui.dialogs.course_list_dialog import CourseListDialog
 from src.gui.workers.processing_worker import ProcessingWorker
 
 
@@ -161,6 +162,22 @@ class MainWindow(QWidget):
             field = InputField(config)
             self.input_fields[field_name] = field
 
+            # URL 필드: 라벨 옆에 "강의 목록에서 선택" 버튼 추가
+            if field_name == 'urls':
+                url_header = QHBoxLayout()
+                url_header.addWidget(field.label)
+                url_header.addStretch()
+
+                self.browse_courses_btn = AppButton("강의 목록에서 선택", "outline")
+                self.browse_courses_btn.setIcon(AppIcons.icon('book'))
+                self.browse_courses_btn.setFixedWidth(170)
+                self.browse_courses_btn.clicked.connect(self._open_course_list_dialog)
+                url_header.addWidget(self.browse_courses_btn)
+
+                card_layout.addLayout(url_header)
+                card_layout.addWidget(field.widget)
+                continue
+
             card_layout.addWidget(field.label)
             card_layout.addWidget(field.widget)
 
@@ -240,6 +257,35 @@ class MainWindow(QWidget):
     def _open_settings_dialog(self):
         dialog = SettingsDialog(self)
         dialog.exec_()
+
+    def _open_course_list_dialog(self):
+        """강의 목록 다이얼로그를 열어 URL을 선택한다."""
+        student_id = self.input_fields['student_id'].get_value().strip()
+        password = self.input_fields['password'].get_value().strip()
+
+        if not student_id or not password:
+            QMessageBox.warning(
+                self, "입력 필요",
+                "학번과 비밀번호를 먼저 입력해주세요."
+            )
+            return
+
+        dialog = CourseListDialog(
+            self, username=student_id, password=password
+        )
+        if dialog.exec_() == QDialog.Accepted:
+            selected_urls = dialog.get_selected_urls()
+            if selected_urls:
+                current = self.input_fields['urls'].get_value().strip()
+                new_urls = '\n'.join(selected_urls)
+                if current:
+                    combined = current + '\n' + new_urls
+                else:
+                    combined = new_urls
+                self.input_fields['urls'].set_value(combined)
+                self.log_area.append_message(
+                    f"강의 목록에서 {len(selected_urls)}개 URL이 추가되었습니다."
+                )
 
     def _open_in_finder(self):
         path = ensure_downloads_directory()
@@ -391,6 +437,8 @@ class MainWindow(QWidget):
     def _set_input_fields_enabled(self, enabled: bool):
         for field in self.input_fields.values():
             field.set_enabled(enabled)
+        if hasattr(self, 'browse_courses_btn'):
+            self.browse_courses_btn.setEnabled(enabled)
 
     def _check_module_status(self):
         if self.module_errors:

--- a/src/gui/workers/course_list_worker.py
+++ b/src/gui/workers/course_list_worker.py
@@ -1,0 +1,77 @@
+"""
+과목/강의 목록을 백그라운드에서 로드하는 워커 스레드
+"""
+
+import asyncio
+import threading
+import traceback
+from typing import Optional
+
+from PyQt5.QtCore import QThread, pyqtSignal
+
+from src.gui.config.course_models import Course
+from src.gui.core.file_manager import get_chrome_path
+
+
+class CourseListWorker(QThread):
+    """과목 또는 강의 목록을 로드하는 워커"""
+
+    log_message = pyqtSignal(str)
+    courses_loaded = pyqtSignal(list)       # List[Course]
+    lectures_loaded = pyqtSignal(object)    # CourseDetail
+    error_occurred = pyqtSignal(str)
+    finished_signal = pyqtSignal()
+
+    def __init__(self, username: str, password: str,
+                 course: Optional[Course] = None):
+        """
+        course=None: 과목 목록 로드
+        course 지정: 해당 과목의 강의 목록 로드
+        """
+        super().__init__()
+        self.username = username
+        self.password = password
+        self.course = course
+        self.chrome_path = get_chrome_path()
+        self._cancel_event = threading.Event()
+
+    def request_cancel(self):
+        self._cancel_event.set()
+
+    def is_cancelled(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def run(self):
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(self._async_run())
+        except Exception as e:
+            if not self._cancel_event.is_set():
+                self.error_occurred.emit(str(e))
+                self.log_message.emit(f"[ERROR] {traceback.format_exc()}")
+        finally:
+            self.finished_signal.emit()
+
+    async def _async_run(self):
+        from src.video_pipeline.course_scraper import CourseScraper
+
+        def log_cb(msg):
+            self.log_message.emit(msg)
+
+        async with CourseScraper(
+            self.username, self.password,
+            chrome_path=self.chrome_path,
+            log_callback=log_cb,
+        ) as scraper:
+            if self._cancel_event.is_set():
+                return
+
+            if self.course is None:
+                courses = await scraper.fetch_courses()
+                if not self._cancel_event.is_set():
+                    self.courses_loaded.emit(courses)
+            else:
+                detail = await scraper.fetch_lectures(self.course)
+                if not self._cancel_event.is_set():
+                    self.lectures_loaded.emit(detail)

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -168,6 +168,10 @@ class ProcessingWorker(QThread):
 
         self._check_cancelled()
         video_paths = video_pipeline.process_sync(urls)
+
+        failed_count = len(urls) - len(video_paths)
+        if failed_count > 0:
+            self._emit_log(f"⚠️ {failed_count}개 영상 다운로드 실패 (건너뜀)")
         self._emit_log(f"{Messages.DOWNLOAD_COMPLETE}: {len(video_paths)}개 파일")
 
         # 다운로드된 파일 목록 출력

--- a/src/video_pipeline/course_scraper.py
+++ b/src/video_pipeline/course_scraper.py
@@ -45,10 +45,12 @@ class CourseScraper:
 
     def __init__(self, username: str, password: str,
                  chrome_path: str = None,
+                 headless: bool = True,
                  log_callback: Optional[Callable[[str], None]] = None):
         self.username = username
         self.password = password
         self.chrome_path = chrome_path or _DEFAULT_CHROME_PATH
+        self.headless = headless
         self._log = log_callback or (lambda msg: None)
         self._pw = None
         self._browser = None
@@ -57,7 +59,7 @@ class CourseScraper:
     async def _setup_browser(self, playwright: Playwright):
         """브라우저 설정 (VideoPipeline._setup_browser 패턴)"""
         browser = await playwright.chromium.launch(
-            headless=False,
+            headless=self.headless,
             executable_path=self.chrome_path,
             args=[
                 "--disable-blink-features=AutomationControlled",
@@ -312,6 +314,14 @@ class CourseScraper:
             if "completed" in comp_classes and "incomplete" not in comp_classes:
                 completion = "completed"
 
+        # 예정 상태 (아직 공개되지 않은 강의)
+        is_upcoming = False
+        dday_el = await el.query_selector(".xncb-component-sub-d_day")
+        if dday_el:
+            dday_classes = await dday_el.get_attribute("class") or ""
+            if "upcoming" in dday_classes:
+                is_upcoming = True
+
         return LectureItem(
             title=title,
             item_url=item_url,
@@ -322,6 +332,7 @@ class CourseScraper:
             attendance=attendance,
             completion=completion,
             content_type_label=content_type_label,
+            is_upcoming=is_upcoming,
         )
 
     # ── 수명 관리 ──────────────────────────────────────────────

--- a/src/video_pipeline/course_scraper.py
+++ b/src/video_pipeline/course_scraper.py
@@ -1,0 +1,349 @@
+"""
+Canvas LMS 과목 목록 및 주차별 강의 목록 스크래퍼
+
+VideoPipeline._setup_browser() 패턴을 재사용하여
+Playwright 비동기 브라우저로 Canvas LMS에서 과목/강의 정보를 추출한다.
+"""
+
+import asyncio
+import re
+from typing import List, Optional, Callable
+
+from playwright.async_api import async_playwright, Playwright, Page, Frame
+
+from src.video_pipeline.login import perform_login_if_needed
+from src.gui.config.course_models import (
+    Course, LectureItem, Week, CourseDetail,
+    LectureType, VIDEO_LECTURE_TYPES,
+)
+
+_BASE_URL = "https://canvas.ssu.ac.kr"
+_DASHBOARD_URL = f"{_BASE_URL}/"
+_LECTURES_URL_TEMPLATE = _BASE_URL + "/courses/{course_id}/external_tools/71"
+
+_DEFAULT_CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+# xnmb-module_item-icon 클래스 → LectureType 매핑
+_TYPE_CLASS_MAP = {
+    "movie": LectureType.MOVIE,
+    "readystream": LectureType.READYSTREAM,
+    "screenlecture": LectureType.SCREENLECTURE,
+    "everlec": LectureType.EVERLEC,
+    "zoom": LectureType.ZOOM,
+    "mp4": LectureType.MP4,
+    "assignment": LectureType.ASSIGNMENT,
+    "wiki_page": LectureType.WIKI_PAGE,
+    "quiz": LectureType.QUIZ,
+    "discussion": LectureType.DISCUSSION,
+    "file": LectureType.FILE,
+    "attachment": LectureType.FILE,
+}
+
+
+class CourseScraper:
+    """Canvas LMS 과목/강의 스크래퍼"""
+
+    def __init__(self, username: str, password: str,
+                 chrome_path: str = None,
+                 log_callback: Optional[Callable[[str], None]] = None):
+        self.username = username
+        self.password = password
+        self.chrome_path = chrome_path or _DEFAULT_CHROME_PATH
+        self._log = log_callback or (lambda msg: None)
+        self._pw = None
+        self._browser = None
+        self._page = None
+
+    async def _setup_browser(self, playwright: Playwright):
+        """브라우저 설정 (VideoPipeline._setup_browser 패턴)"""
+        browser = await playwright.chromium.launch(
+            headless=False,
+            executable_path=self.chrome_path,
+            args=[
+                "--disable-blink-features=AutomationControlled",
+                "--enable-proprietary-codecs",
+                "--disable-web-security",
+                "--use-fake-ui-for-media-stream",
+            ],
+        )
+
+        context = await browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/122.0.0.0 Safari/537.36"
+            ),
+            permissions=["camera", "microphone", "geolocation"],
+        )
+
+        page = await context.new_page()
+        await page.add_init_script("""
+            Object.defineProperty(navigator, 'webdriver', {
+                get: () => undefined,
+            });
+            window.chrome = { runtime: {} };
+        """)
+
+        return page, browser
+
+    async def _ensure_logged_in(self):
+        """대시보드로 이동 후 로그인 처리"""
+        self._log("LMS에 접속 중...")
+        await self._page.goto(_DASHBOARD_URL, wait_until="networkidle")
+
+        if "login" in self._page.url:
+            self._log("로그인 진행 중...")
+            result = await perform_login_if_needed(
+                self._page, self.username, self.password
+            )
+            if not result and "login" in self._page.url:
+                raise RuntimeError("LMS 로그인 실패. 학번/비밀번호를 확인하세요.")
+            self._log("로그인 완료")
+        else:
+            self._log("이미 로그인 상태")
+
+    # ── 과목 목록 ──────────────────────────────────────────────
+
+    async def fetch_courses(self) -> List[Course]:
+        """대시보드에서 수강 과목 목록 추출"""
+        # 대시보드가 아닌 경우 이동
+        if "canvas.ssu.ac.kr" not in self._page.url or "/courses/" in self._page.url:
+            await self._page.goto(_DASHBOARD_URL, wait_until="networkidle")
+
+        raw = await self._page.evaluate(
+            "() => window.ENV && window.ENV.STUDENT_PLANNER_COURSES"
+        )
+
+        if not raw:
+            raise RuntimeError(
+                "과목 목록을 불러올 수 없습니다. 페이지를 확인하세요."
+            )
+
+        courses = []
+        for item in raw:
+            courses.append(Course(
+                id=str(item["id"]),
+                long_name=item.get("longName", ""),
+                href=item.get("href", f"/courses/{item['id']}"),
+                term=item.get("term", ""),
+                is_favorited=item.get("isFavorited", False),
+            ))
+
+        self._log(f"{len(courses)}개 과목 로드 완료")
+        return courses
+
+    # ── 주차별 강의 목록 ──────────────────────────────────────
+
+    async def fetch_lectures(self, course: Course) -> CourseDetail:
+        """과목의 주차별 강의 목록 페이지를 파싱"""
+        url = _LECTURES_URL_TEMPLATE.format(course_id=course.id)
+        self._log(f"강의 목록 로딩: {course.long_name}")
+        await self._page.goto(url, wait_until="networkidle")
+
+        # tool_content iframe 대기
+        iframe_el = await self._page.wait_for_selector(
+            "iframe#tool_content", timeout=15000
+        )
+        iframe = await iframe_el.content_frame()
+        if not iframe:
+            raise RuntimeError("tool_content iframe을 찾을 수 없습니다.")
+
+        # LTI 콘텐츠 로드 대기
+        await iframe.wait_for_selector("#root", timeout=15000)
+        await asyncio.sleep(0.5)  # 렌더링 안정화
+
+        # 메타데이터 추출
+        root = await iframe.query_selector("#root")
+        course_name = await root.get_attribute("data-course_name") or course.long_name
+        professors = await root.get_attribute("data-professors") or ""
+
+        # 전체 펼치기
+        expand_btn = await iframe.query_selector(".xnmb-all_fold-btn")
+        if expand_btn:
+            btn_text = await expand_btn.text_content()
+            if btn_text and "펼치기" in btn_text:
+                await expand_btn.click()
+                await asyncio.sleep(0.5)
+
+        # 주차 파싱
+        weeks = await self._parse_weeks(iframe)
+
+        total_items = sum(len(w.lectures) for w in weeks)
+        total_videos = sum(len(w.video_lectures) for w in weeks)
+        self._log(f"{len(weeks)}개 주차, {total_items}개 항목 ({total_videos}개 동영상) 파싱 완료")
+
+        return CourseDetail(
+            course=course,
+            course_name=course_name,
+            professors=professors,
+            weeks=weeks,
+        )
+
+    async def _parse_weeks(self, iframe: Frame) -> List[Week]:
+        """모든 주차 모듈 파싱"""
+        # 주차 래퍼들은 .xnmb-module-list 직계 자식 div들
+        # 각 div는 .xnmb-module-outer-wrapper(헤더) + 아이템 컨테이너로 구성
+        module_list = await iframe.query_selector(".xnmb-module-list")
+        if not module_list:
+            return []
+
+        # 주차 모듈의 상위 div들 (헤더 div 제외)
+        top_divs = await module_list.query_selector_all(":scope > div")
+
+        weeks = []
+        for div in top_divs:
+            # 주차 헤더가 있는 div인지 확인
+            header = await div.query_selector(".xnmb-module-outer-wrapper")
+            if not header:
+                continue
+
+            # 주차 제목
+            title_el = await header.query_selector(".xnmb-module-title")
+            title = (await title_el.text_content()).strip() if title_el else ""
+
+            week_num = len(weeks) + 1
+            match = re.search(r'(\d+)주차', title)
+            if match:
+                week_num = int(match.group(1))
+
+            # 아이템들은 header의 sibling div 안에 있음
+            items = await div.query_selector_all(
+                ".xnmb-module_item-outer-wrapper"
+            )
+
+            lectures = []
+            for item_el in items:
+                lecture = await self._parse_item(item_el)
+                if lecture:
+                    lectures.append(lecture)
+
+            weeks.append(Week(
+                title=title,
+                week_number=week_num,
+                lectures=lectures,
+            ))
+
+        return weeks
+
+    async def _parse_item(self, el) -> Optional[LectureItem]:
+        """개별 강의 아이템 파싱"""
+        # 타입 판별
+        icon_el = await el.query_selector("i.xnmb-module_item-icon")
+        lecture_type = LectureType.OTHER
+        if icon_el:
+            classes = await icon_el.get_attribute("class") or ""
+            for cls_name, lt in _TYPE_CLASS_MAP.items():
+                if cls_name in classes.split():
+                    lecture_type = lt
+                    break
+
+        # 제목 & URL
+        title_el = await el.query_selector("a.xnmb-module_item-left-title")
+        if not title_el:
+            # 링크 없는 아이템 (제목만 있는 경우)
+            title_el = await el.query_selector(
+                ".xnmb-module_item-left-title"
+            )
+            if not title_el:
+                return None
+            title = (await title_el.text_content() or "").strip()
+            item_url = ""
+        else:
+            title = (await title_el.text_content() or "").strip()
+            item_url = await title_el.get_attribute("href") or ""
+            # return_url 파라미터 제거
+            if "?" in item_url:
+                item_url = item_url.split("?")[0]
+
+        if not title:
+            return None
+
+        # 영상 길이
+        duration = None
+        periods_el = await el.query_selector(
+            "[class*='lecture_periods']"
+        )
+        if periods_el:
+            spans = await periods_el.query_selector_all("span")
+            for span in reversed(spans):
+                text = (await span.text_content() or "").strip()
+                if re.match(r'^\d+:\d+$', text):
+                    duration = text
+                    break
+
+        # 주차/차시
+        week_label = ""
+        lesson_label = ""
+        content_type_label = ""
+
+        week_span = await el.query_selector(
+            "[class*='lesson_periods-week']"
+        )
+        if week_span:
+            week_label = (await week_span.text_content() or "").strip()
+
+        lesson_span = await el.query_selector(
+            "[class*='lesson_periods-lesson']"
+        )
+        if lesson_span:
+            lesson_label = (await lesson_span.text_content() or "").strip()
+
+        type_span = await el.query_selector(
+            "[class*='lesson_periods-dates'] span"
+        )
+        if type_span:
+            content_type_label = (await type_span.text_content() or "").strip()
+
+        # 출석 상태
+        attendance = "none"
+        att_el = await el.query_selector("[class*='attendance_status']")
+        if att_el:
+            att_classes = await att_el.get_attribute("class") or ""
+            for status in ("attendance", "late", "absent", "excused"):
+                if status in att_classes:
+                    attendance = status
+                    break
+
+        # 완료 상태
+        completion = "incomplete"
+        comp_el = await el.query_selector("[class*='module_item-completed']")
+        if comp_el:
+            comp_classes = await comp_el.get_attribute("class") or ""
+            if "completed" in comp_classes and "incomplete" not in comp_classes:
+                completion = "completed"
+
+        return LectureItem(
+            title=title,
+            item_url=item_url,
+            lecture_type=lecture_type,
+            week_label=week_label,
+            lesson_label=lesson_label,
+            duration=duration,
+            attendance=attendance,
+            completion=completion,
+            content_type_label=content_type_label,
+        )
+
+    # ── 수명 관리 ──────────────────────────────────────────────
+
+    async def start(self):
+        """브라우저 시작 및 로그인"""
+        self._pw = await async_playwright().start()
+        self._page, self._browser = await self._setup_browser(self._pw)
+        await self._ensure_logged_in()
+
+    async def close(self):
+        """브라우저 종료"""
+        if self._browser:
+            await self._browser.close()
+            self._browser = None
+        if self._pw:
+            await self._pw.stop()
+            self._pw = None
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()

--- a/src/video_pipeline/pipeline.py
+++ b/src/video_pipeline/pipeline.py
@@ -101,17 +101,28 @@ class VideoPipeline:
     async def process(self, urls: list[str]) -> list[str]:
         """비디오 다운로드 파이프라인 실행"""
         downloaded_videos_path = []
+        failed_urls = []
 
         async with async_playwright() as p:
             page, browser = await self._setup_browser(p)
 
             try:
-                for url in urls:
-                    filepath = await self._process_single_url(page, url)
-                    if filepath:
-                        downloaded_videos_path.append(filepath)
+                for i, url in enumerate(urls, 1):
+                    try:
+                        filepath = await self._process_single_url(page, url)
+                        if filepath:
+                            downloaded_videos_path.append(filepath)
+                    except Exception as e:
+                        print(f"[ERROR] ({i}/{len(urls)}) 다운로드 실패, 다음 영상으로 진행: {url}")
+                        print(f"[ERROR] 원인: {e}")
+                        failed_urls.append((url, str(e)))
             finally:
                 await browser.close()
+
+        if failed_urls:
+            print(f"\n[WARN] {len(failed_urls)}개 영상 다운로드 실패:")
+            for url, err in failed_urls:
+                print(f"  - {url}: {err}")
 
         return downloaded_videos_path
 

--- a/src/video_pipeline/pipeline.py
+++ b/src/video_pipeline/pipeline.py
@@ -36,7 +36,7 @@ class VideoPipeline:
     async def _setup_browser(self, playwright: Playwright) -> Tuple[Page, any]:
         """브라우저 설정 및 페이지 생성"""
         browser = await playwright.chromium.launch(
-            headless=False,
+            headless=True,
             executable_path=self.chrome_path,
             args=[
                 "--disable-blink-features=AutomationControlled",


### PR DESCRIPTION
## Summary
- Canvas LMS 대시보드에서 수강 과목 목록을 불러오고, 주차별 강의 영상을 선택하여 URL을 자동 입력하는 기능 추가
- 예정(upcoming) 강의 항목 비활성화 표시, 로딩 인디케이터, headless 파라미터 지원
- 영상 다운로드 실패(403 등) 시 전체 파이프라인이 멈추던 버그 수정 — 실패한 영상을 건너뛰고 나머지 계속 처리

## Changes
- `course_models.py`: 강의 데이터 모델 (Course, Week, LectureItem 등)
- `course_scraper.py`: Playwright 기반 Canvas LMS 스크래퍼
- `course_list_dialog.py`: 2단계 선택 다이얼로그 (과목 → 주차별 영상)
- `course_list_worker.py`: QThread 워커 (비동기 스크래핑)
- `pipeline.py`: 개별 URL 실패 시 건너뛰기 예외처리
- `processing_worker.py`: 실패 건수 로그 출력
- `main_window.py`, `styles.py`, `icons.py`, `file_manager.py`: UI 통합

## Test plan
- [x] 강의 목록 불러오기 → 과목 선택 → 영상 선택 → URL 자동 입력 확인
- [x] 예정 항목이 회색 비활성화로 표시되는지 확인
- [x] 로딩 프로그레스바가 양쪽 Phase에서 표시되는지 확인
- [x] 403 에러 영상 포함 시 나머지 영상이 정상 다운로드되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)