### PR TITLE
feat: whisper.cpp 마이그레이션으로 빌드 경량화

### DIFF
--- a/lms-summarizer.spec
+++ b/lms-summarizer.spec
@@ -20,15 +20,20 @@ APP_NAME = "LMS-Summarizer"
 APP_VERSION = "1.3.0"
 
 # faster-whisper 모델 캐시 경로 (huggingface hub 캐시)
+# 심볼릭 링크를 해제하여 실제 파일을 복사
 def find_whisper_models():
     home = Path.home()
-    # faster-whisper는 huggingface_hub 캐시를 사용
     hf_cache = home / ".cache" / "huggingface" / "hub"
     if hf_cache.exists():
         for d in hf_cache.iterdir():
             if d.is_dir() and "whisper" in d.name:
+                # snapshots 내부의 최신 디렉토리를 찾아 실제 파일 경로 반환
+                snapshots = d / "snapshots"
+                if snapshots.exists():
+                    for snap in sorted(snapshots.iterdir(), reverse=True):
+                        if snap.is_dir():
+                            return str(snap)
                 return str(d)
-    # openai-whisper 레거시 캐시도 확인
     whisper_cache = home / ".cache" / "whisper"
     if whisper_cache.exists():
         return str(whisper_cache)
@@ -81,9 +86,28 @@ if whisper_cache:
 if certifi_cacert:
     datas.append((certifi_cacert, "certifi"))
 
-# 바이너리: CTranslate2 네이티브 라이브러리
+# pywhispercpp 네이티브 라이브러리 수집
+def collect_pywhispercpp_libs():
+    """pywhispercpp의 네이티브 바이너리를 수집"""
+    binaries = []
+    try:
+        import pywhispercpp
+        pwc_dir = os.path.dirname(pywhispercpp.__file__)
+        for f in os.listdir(pwc_dir):
+            full = os.path.join(pwc_dir, f)
+            if os.path.isfile(full) and (
+                f.endswith(".dll") or f.endswith(".pyd") or
+                f.endswith(".so") or f.endswith(".dylib")
+            ):
+                binaries.append((full, "pywhispercpp"))
+    except ImportError:
+        print("[WARNING] pywhispercpp not found, skipping lib collection")
+    return binaries
+
+# 바이너리: CTranslate2 + pywhispercpp 네이티브 라이브러리
 binaries = []
 binaries.extend(collect_ctranslate2_libs())
+binaries.extend(collect_pywhispercpp_libs())
 
 a = Analysis(
     ["src/gui/main.py"],
@@ -112,10 +136,12 @@ a = Analysis(
         "src.gui.config.settings",
         "src.gui.config.course_models",
         # 외부 라이브러리
-        "openai", "faster_whisper", "playwright", "requests",
+        "openai", "faster_whisper", "pywhispercpp", "playwright", "requests",
         "dotenv", "google.generativeai", "certifi",
         # faster-whisper 의존성
         "ctranslate2", "tokenizers", "huggingface_hub", "av",
+        # pywhispercpp 의존성
+        "pywhispercpp.model", "pywhispercpp.utils",
         # 표준 라이브러리
         "json", "threading", "pathlib",
     ],

--- a/lms-summarizer.spec
+++ b/lms-summarizer.spec
@@ -7,64 +7,17 @@
 #   Windows: pyinstaller lms-summarizer.spec
 #
 # 용량 최적화 참고:
-#   - faster-whisper (CTranslate2): ~80MB (torch 대비 대폭 절감)
-#   - whisper base 모델: ~142MB → 번들에 포함
+#   - whisper.cpp (pywhispercpp): ~2MB (faster-whisper/CTranslate2 대비 대폭 절감)
+#   - whisper base ggml 모델: ~142MB → 자동 다운로드 (번들 미포함)
 #   - Flet: ~20MB
-#   - 전체 예상: ~250-350MB (압축 전), ZIP 시 ~150-200MB
+#   - 전체 예상: ~150-200MB (압축 전)
 
 import sys
 import os
 from pathlib import Path
 
 APP_NAME = "LMS-Summarizer"
-APP_VERSION = "1.3.0"
-
-# faster-whisper 모델 캐시 경로 (huggingface hub 캐시)
-# 심볼릭 링크를 해제하여 실제 파일을 복사
-def find_whisper_models():
-    home = Path.home()
-    hf_cache = home / ".cache" / "huggingface" / "hub"
-    if hf_cache.exists():
-        for d in hf_cache.iterdir():
-            if d.is_dir() and "whisper" in d.name:
-                # snapshots 내부의 최신 디렉토리를 찾아 실제 파일 경로 반환
-                snapshots = d / "snapshots"
-                if snapshots.exists():
-                    for snap in sorted(snapshots.iterdir(), reverse=True):
-                        if snap.is_dir():
-                            return str(snap)
-                return str(d)
-    whisper_cache = home / ".cache" / "whisper"
-    if whisper_cache.exists():
-        return str(whisper_cache)
-    return None
-
-# CTranslate2 라이브러리 수집
-def collect_ctranslate2_libs():
-    """CTranslate2의 네이티브 바이너리를 수집"""
-    binaries = []
-    try:
-        import ctranslate2
-        ct2_dir = os.path.dirname(ctranslate2.__file__)
-        for f in os.listdir(ct2_dir):
-            full = os.path.join(ct2_dir, f)
-            if os.path.isfile(full) and (
-                f.endswith(".dll") or f.endswith(".pyd") or
-                f.endswith(".so") or f.endswith(".dylib")
-            ):
-                binaries.append((full, "ctranslate2"))
-        lib_dir = os.path.join(ct2_dir, "lib")
-        if os.path.isdir(lib_dir):
-            for f in os.listdir(lib_dir):
-                full = os.path.join(lib_dir, f)
-                if os.path.isfile(full):
-                    binaries.append((full, "ctranslate2/lib"))
-    except ImportError:
-        print("[WARNING] ctranslate2 not found, skipping lib collection")
-    return binaries
-
-
-whisper_cache = find_whisper_models()
+APP_VERSION = "1.4.0"
 
 # SSL 인증서 번들 경로 (PyInstaller에서 requests HTTPS 요청에 필요)
 def find_certifi_cacert():
@@ -75,16 +28,6 @@ def find_certifi_cacert():
         return None
 
 certifi_cacert = find_certifi_cacert()
-
-# 추가 데이터 파일
-datas = [
-    ("src", "src"),
-    ("assets", "assets"),
-]
-if whisper_cache:
-    datas.append((whisper_cache, "whisper_models"))
-if certifi_cacert:
-    datas.append((certifi_cacert, "certifi"))
 
 # pywhispercpp 네이티브 라이브러리 수집
 def collect_pywhispercpp_libs():
@@ -104,9 +47,16 @@ def collect_pywhispercpp_libs():
         print("[WARNING] pywhispercpp not found, skipping lib collection")
     return binaries
 
-# 바이너리: CTranslate2 + pywhispercpp 네이티브 라이브러리
+# 추가 데이터 파일
+datas = [
+    ("src", "src"),
+    ("assets", "assets"),
+]
+if certifi_cacert:
+    datas.append((certifi_cacert, "certifi"))
+
+# 바이너리: pywhispercpp 네이티브 라이브러리
 binaries = []
-binaries.extend(collect_ctranslate2_libs())
 binaries.extend(collect_pywhispercpp_libs())
 
 a = Analysis(
@@ -136,10 +86,8 @@ a = Analysis(
         "src.gui.config.settings",
         "src.gui.config.course_models",
         # 외부 라이브러리
-        "openai", "faster_whisper", "pywhispercpp", "playwright", "requests",
+        "openai", "pywhispercpp", "playwright", "requests",
         "dotenv", "google.generativeai", "certifi",
-        # faster-whisper 의존성
-        "ctranslate2", "tokenizers", "huggingface_hub", "av",
         # pywhispercpp 의존성
         "pywhispercpp.model", "pywhispercpp.utils",
         # 표준 라이브러리
@@ -153,8 +101,10 @@ a = Analysis(
         "tkinter", "matplotlib", "PIL", "Pillow",
         "scipy", "pandas", "notebook", "jupyter",
         "IPython", "cv2", "sklearn",
-        # torch (faster-whisper로 대체하여 불필요)
+        # torch (불필요)
         "torch", "torch._C", "torch.nn", "torch.backends",
+        # faster-whisper / CTranslate2 (whisper.cpp로 대체)
+        "faster_whisper", "ctranslate2", "tokenizers", "huggingface_hub", "av",
         # PyQt5 (더 이상 사용하지 않음)
         "PyQt5", "PyQt5.QtCore", "PyQt5.QtWidgets", "PyQt5.QtGui",
         "qtawesome",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "google-generativeai>=0.8.3",
     "openai>=1.84.0",
     "faster-whisper>=1.1.0",
+    "pywhispercpp>=1.4.0",
     "playwright>=1.52.0",
     "pyperclip>=1.9.0",
     "flet[all]>=0.81.0,<1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.11,<3.13"
 dependencies = [
     "google-generativeai>=0.8.3",
     "openai>=1.84.0",
-    "faster-whisper>=1.1.0",
     "pywhispercpp>=1.4.0",
     "playwright>=1.52.0",
     "pyperclip>=1.9.0",

--- a/src/audio_pipeline/pipeline.py
+++ b/src/audio_pipeline/pipeline.py
@@ -6,7 +6,7 @@ from src.audio_pipeline.transcriber import transcribe_audio_to_text
 
 
 class AudioToTextPipeline:
-    def __init__(self, sample_rate=16000, engine="whisper"):
+    def __init__(self, sample_rate=16000, engine="whisper-cpp"):
         self.sample_rate = sample_rate
         self.engine = engine
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
@@ -21,18 +21,14 @@ class AudioToTextPipeline:
         print(f"[INFO] 변환 시작: {mp4_path}")
         start_time = time.time()
 
-        if self.engine in ("returnzero", "whisper-cpp"):
-            # ReturnZero, whisper.cpp는 WAV 입력이 필요
-            from src.audio_pipeline.converter import convert_mp4_to_wav
-            wav_path = os.path.join(self.downloads_dir, f"{filename}.wav")
-            convert_mp4_to_wav(mp4_path, wav_path, self.sample_rate)
-            transcribe_audio_to_text(wav_path, txt_path, engine=self.engine)
-            if remove_wav:
-                os.remove(wav_path)
-                print(f"[INFO] 임시 파일 삭제됨: {wav_path}")
-        else:
-            # faster-whisper: MP4 직접 입력 (ffmpeg 불필요)
-            transcribe_audio_to_text(mp4_path, txt_path, engine=self.engine)
+        # whisper.cpp, ReturnZero 모두 WAV 입력 필요
+        from src.audio_pipeline.converter import convert_mp4_to_wav
+        wav_path = os.path.join(self.downloads_dir, f"{filename}.wav")
+        convert_mp4_to_wav(mp4_path, wav_path, self.sample_rate)
+        transcribe_audio_to_text(wav_path, txt_path, engine=self.engine)
+        if remove_wav:
+            os.remove(wav_path)
+            print(f"[INFO] 임시 파일 삭제됨: {wav_path}")
 
         end_time = time.time()
         print(f"[DONE] 텍스트 저장 완료: {txt_path}")

--- a/src/audio_pipeline/pipeline.py
+++ b/src/audio_pipeline/pipeline.py
@@ -21,12 +21,12 @@ class AudioToTextPipeline:
         print(f"[INFO] 변환 시작: {mp4_path}")
         start_time = time.time()
 
-        if self.engine == "returnzero":
-            # ReturnZero는 WAV 입력이 필요
+        if self.engine in ("returnzero", "whisper-cpp"):
+            # ReturnZero, whisper.cpp는 WAV 입력이 필요
             from src.audio_pipeline.converter import convert_mp4_to_wav
             wav_path = os.path.join(self.downloads_dir, f"{filename}.wav")
             convert_mp4_to_wav(mp4_path, wav_path, self.sample_rate)
-            transcribe_audio_to_text(wav_path, txt_path, engine="returnzero")
+            transcribe_audio_to_text(wav_path, txt_path, engine=self.engine)
             if remove_wav:
                 os.remove(wav_path)
                 print(f"[INFO] 임시 파일 삭제됨: {wav_path}")

--- a/src/audio_pipeline/transcriber.py
+++ b/src/audio_pipeline/transcriber.py
@@ -1,6 +1,5 @@
 import json
 import time
-from faster_whisper import WhisperModel
 from abc import ABC, abstractmethod
 import os
 import requests
@@ -13,6 +12,8 @@ def transcribe_audio_to_text(audio_path: str, txt_path: str, engine="whisper"):
     """오디오/비디오 파일을 텍스트로 변환 (MP4 직접 입력 지원)"""
     if engine == "whisper":
         transcriber = WhisperTranscriber()
+    elif engine == "whisper-cpp":
+        transcriber = WhisperCppTranscriber()
     elif engine == "returnzero":
         transcriber = ReturnZeroTranscriber()
     else:
@@ -33,6 +34,7 @@ class Transcriber(ABC):
 
 class WhisperTranscriber(Transcriber):
     def __init__(self, model_name="base"):
+        from faster_whisper import WhisperModel
         import sys
 
         load_start = time.time()
@@ -63,6 +65,45 @@ class WhisperTranscriber(Transcriber):
             self.last_transcribe_sec = time.time() - transcribe_start
             print(f"[Whisper] 변환 완료 (언어: {info.language}, 확률: {info.language_probability:.2f}): {txt_path}")
             print(f"[Whisper] STT 소요 시간: {self.last_transcribe_sec:.1f}초")
+        except Exception as e:
+            print(f"[ERROR] 변환 실패: {e}")
+            raise e
+
+
+class WhisperCppTranscriber(Transcriber):
+    def __init__(self, model_name="base", language="ko"):
+        from pywhispercpp.model import Model
+        import sys
+
+        self._language = language
+        load_start = time.time()
+
+        # .app 번들 내부의 모델 확인
+        if getattr(sys, 'frozen', False):
+            model_path = os.path.join(sys._MEIPASS, 'whisper_models', f'ggml-{model_name}.bin')
+            if os.path.exists(model_path):
+                print(f"[INFO] 번들된 whisper.cpp 모델 사용: {model_path}")
+                self.model = Model(model_path)
+                self.model_load_sec = time.time() - load_start
+                print(f"[INFO] 모델 로드 시간: {self.model_load_sec:.1f}초")
+                return
+
+        # 기본 경로에서 모델 로드 (자동 다운로드)
+        print(f"[INFO] whisper.cpp 모델 로드 중: {model_name}")
+        self.model = Model(model_name)
+        self.model_load_sec = time.time() - load_start
+        print(f"[INFO] 모델 로드 시간: {self.model_load_sec:.1f}초")
+
+    def transcribe(self, audio_path: str, txt_path: str):
+        try:
+            transcribe_start = time.time()
+            segments = self.model.transcribe(audio_path, language=self._language)
+            text = " ".join(segment.text.strip() for segment in segments if segment.text.strip())
+            with open(txt_path, "w", encoding="utf-8") as f:
+                f.write(text)
+            self.last_transcribe_sec = time.time() - transcribe_start
+            print(f"[whisper.cpp] 변환 완료: {txt_path}")
+            print(f"[whisper.cpp] STT 소요 시간: {self.last_transcribe_sec:.1f}초")
         except Exception as e:
             print(f"[ERROR] 변환 실패: {e}")
             raise e

--- a/src/audio_pipeline/transcriber.py
+++ b/src/audio_pipeline/transcriber.py
@@ -8,11 +8,9 @@ from src.user_setting import UserSetting
 # https://developers.rtzr.ai/docs/stt-file/
 
 
-def transcribe_audio_to_text(audio_path: str, txt_path: str, engine="whisper"):
-    """오디오/비디오 파일을 텍스트로 변환 (MP4 직접 입력 지원)"""
-    if engine == "whisper":
-        transcriber = WhisperTranscriber()
-    elif engine == "whisper-cpp":
+def transcribe_audio_to_text(audio_path: str, txt_path: str, engine="whisper-cpp"):
+    """오디오/비디오 파일을 텍스트로 변환"""
+    if engine == "whisper-cpp":
         transcriber = WhisperCppTranscriber()
     elif engine == "returnzero":
         transcriber = ReturnZeroTranscriber()
@@ -30,44 +28,6 @@ class Transcriber(ABC):
     @abstractmethod
     def transcribe(self, audio_path: str, txt_path: str):
         pass
-
-
-class WhisperTranscriber(Transcriber):
-    def __init__(self, model_name="base"):
-        from faster_whisper import WhisperModel
-        import sys
-
-        load_start = time.time()
-
-        # .app 번들 내부의 모델 확인
-        if getattr(sys, 'frozen', False):
-            model_path = os.path.join(sys._MEIPASS, 'whisper_models', model_name)
-            if os.path.exists(model_path):
-                print(f"[INFO] 번들된 Whisper 모델 사용: {model_path}")
-                self.model = WhisperModel(model_path, compute_type="int8")
-                self.model_load_sec = time.time() - load_start
-                print(f"[INFO] 모델 로드 시간: {self.model_load_sec:.1f}초")
-                return
-
-        # 기본 경로에서 모델 로드 (자동 다운로드)
-        print(f"[INFO] Whisper 모델 로드 중: {model_name}")
-        self.model = WhisperModel(model_name, compute_type="int8")
-        self.model_load_sec = time.time() - load_start
-        print(f"[INFO] 모델 로드 시간: {self.model_load_sec:.1f}초")
-
-    def transcribe(self, audio_path: str, txt_path: str):
-        try:
-            transcribe_start = time.time()
-            segments, info = self.model.transcribe(audio_path)
-            text = " ".join(segment.text for segment in segments)
-            with open(txt_path, "w", encoding="utf-8") as f:
-                f.write(text)
-            self.last_transcribe_sec = time.time() - transcribe_start
-            print(f"[Whisper] 변환 완료 (언어: {info.language}, 확률: {info.language_probability:.2f}): {txt_path}")
-            print(f"[Whisper] STT 소요 시간: {self.last_transcribe_sec:.1f}초")
-        except Exception as e:
-            print(f"[ERROR] 변환 실패: {e}")
-            raise e
 
 
 class WhisperCppTranscriber(Transcriber):

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -194,25 +194,9 @@ def set_summary_prompt(prompt: str) -> None:
 
 # ── STT 엔진 ──────────────────────────────────────────────
 
-STT_ENGINES = {
-    "whisper": "faster-whisper (기본, GPU 가속)",
-    "whisper-cpp": "whisper.cpp (경량, Apple Silicon 최적화)",
-}
-
-DEFAULT_STT_ENGINE = "whisper"
-
-
 def get_stt_engine() -> str:
-    """저장된 STT 엔진 반환. 없으면 기본값."""
-    engine = load_settings().get("stt_engine", DEFAULT_STT_ENGINE)
-    return engine if engine in STT_ENGINES else DEFAULT_STT_ENGINE
-
-
-def set_stt_engine(engine: str) -> None:
-    """STT 엔진을 settings.json에 저장"""
-    settings = load_settings()
-    settings["stt_engine"] = engine
-    save_settings(settings)
+    """STT 엔진 반환. whisper.cpp 단일 엔진."""
+    return "whisper-cpp"
 
 
 # ── Chrome 경로 ────────────────────────────────────────────

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -192,6 +192,29 @@ def set_summary_prompt(prompt: str) -> None:
     save_settings(settings)
 
 
+# ── STT 엔진 ──────────────────────────────────────────────
+
+STT_ENGINES = {
+    "whisper": "faster-whisper (기본, GPU 가속)",
+    "whisper-cpp": "whisper.cpp (경량, Apple Silicon 최적화)",
+}
+
+DEFAULT_STT_ENGINE = "whisper"
+
+
+def get_stt_engine() -> str:
+    """저장된 STT 엔진 반환. 없으면 기본값."""
+    engine = load_settings().get("stt_engine", DEFAULT_STT_ENGINE)
+    return engine if engine in STT_ENGINES else DEFAULT_STT_ENGINE
+
+
+def set_stt_engine(engine: str) -> None:
+    """STT 엔진을 settings.json에 저장"""
+    settings = load_settings()
+    settings["stt_engine"] = engine
+    save_settings(settings)
+
+
 # ── Chrome 경로 ────────────────────────────────────────────
 
 _CHROME_PATHS = {

--- a/src/gui/views/settings_view.py
+++ b/src/gui/views/settings_view.py
@@ -11,7 +11,6 @@ from src.gui.core.file_manager import (
     get_summary_prompt, set_summary_prompt,
     get_chrome_path, set_chrome_path, detect_chrome_paths,
     get_debug_mode, set_debug_mode,
-    STT_ENGINES, get_stt_engine, set_stt_engine,
 )
 
 
@@ -63,23 +62,6 @@ def open_settings_dialog(page: ft.Page):
                 )
             )
 
-    # STT 엔진 선택
-    current_engine = get_stt_engine()
-    engine_dropdown = ft.Dropdown(
-        value=current_engine,
-        options=[
-            ft.dropdown.Option(key=key, text=label)
-            for key, label in STT_ENGINES.items()
-        ],
-        label="STT 엔진",
-        label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
-        border_radius=Radius.SM,
-        border_color=Colors.BORDER,
-        focused_border_color=Colors.PRIMARY,
-        text_size=Typography.BODY,
-        leading_icon=ft.Icons.RECORD_VOICE_OVER,
-    )
-
     def _set_chrome_path(path):
         chrome_field.value = path
         chrome_field.update()
@@ -102,7 +84,6 @@ def open_settings_dialog(page: ft.Page):
         chrome_path = (chrome_field.value or "").strip()
 
         set_summary_prompt(prompt if prompt else DEFAULT_PROMPT)
-        set_stt_engine(engine_dropdown.value or current_engine)
         set_debug_mode(debug_switch.value)
 
         if chrome_path:
@@ -159,14 +140,6 @@ def open_settings_dialog(page: ft.Page):
                         ),
                         on_click=_reset_prompt,
                     ),
-                    divider(),
-                    # STT 엔진 섹션
-                    ft.Text(
-                        "음성 → 텍스트 변환에 사용할 엔진을 선택합니다.",
-                        size=Typography.SMALL,
-                        color=Colors.TEXT_MUTED,
-                    ),
-                    engine_dropdown,
                     divider(),
                     # Chrome 경로 섹션
                     ft.Text(

--- a/src/gui/views/settings_view.py
+++ b/src/gui/views/settings_view.py
@@ -11,6 +11,7 @@ from src.gui.core.file_manager import (
     get_summary_prompt, set_summary_prompt,
     get_chrome_path, set_chrome_path, detect_chrome_paths,
     get_debug_mode, set_debug_mode,
+    STT_ENGINES, get_stt_engine, set_stt_engine,
 )
 
 
@@ -62,6 +63,23 @@ def open_settings_dialog(page: ft.Page):
                 )
             )
 
+    # STT 엔진 선택
+    current_engine = get_stt_engine()
+    engine_dropdown = ft.Dropdown(
+        value=current_engine,
+        options=[
+            ft.dropdown.Option(key=key, text=label)
+            for key, label in STT_ENGINES.items()
+        ],
+        label="STT 엔진",
+        label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
+        border_radius=Radius.SM,
+        border_color=Colors.BORDER,
+        focused_border_color=Colors.PRIMARY,
+        text_size=Typography.BODY,
+        leading_icon=ft.Icons.RECORD_VOICE_OVER,
+    )
+
     def _set_chrome_path(path):
         chrome_field.value = path
         chrome_field.update()
@@ -84,6 +102,7 @@ def open_settings_dialog(page: ft.Page):
         chrome_path = (chrome_field.value or "").strip()
 
         set_summary_prompt(prompt if prompt else DEFAULT_PROMPT)
+        set_stt_engine(engine_dropdown.value or current_engine)
         set_debug_mode(debug_switch.value)
 
         if chrome_path:
@@ -140,6 +159,14 @@ def open_settings_dialog(page: ft.Page):
                         ),
                         on_click=_reset_prompt,
                     ),
+                    divider(),
+                    # STT 엔진 섹션
+                    ft.Text(
+                        "음성 → 텍스트 변환에 사용할 엔진을 선택합니다.",
+                        size=Typography.SMALL,
+                        color=Colors.TEXT_MUTED,
+                    ),
+                    engine_dropdown,
                     divider(),
                     # Chrome 경로 섹션
                     ft.Text(

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -13,8 +13,8 @@ from typing import Dict, List, Callable, Optional
 from src.gui.config.constants import Messages
 from src.gui.core.file_manager import (
     create_config_files, extract_urls_from_input, ensure_downloads_directory,
-    get_summary_prompt, get_chrome_path, get_debug_mode, add_history_entry,
-    get_app_data_dir,
+    get_summary_prompt, get_chrome_path, get_debug_mode, get_stt_engine,
+    add_history_entry, get_app_data_dir,
 )
 from src.gui.core.module_loader import check_required_modules
 
@@ -58,6 +58,7 @@ class ProcessingWorker:
         self.summary_prompt = get_summary_prompt()
         self.chrome_path = get_chrome_path()
         self.debug_mode = get_debug_mode()
+        self.stt_engine = get_stt_engine()
         self._cancel_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
 
@@ -243,7 +244,8 @@ class ProcessingWorker:
     def _convert_audio_to_text(self, video_paths: List[str]) -> List[str]:
         self._emit_log(Messages.AUDIO_CONVERTING)
 
-        audio_pipeline = self.modules['AudioToTextPipeline']()
+        audio_pipeline = self.modules['AudioToTextPipeline'](engine=self.stt_engine)
+        self._emit_log(f"STT 엔진: {self.stt_engine}")
         text_paths = []
 
         for i, video_path in enumerate(video_paths, 1):

--- a/uv.lock
+++ b/uv.lock
@@ -54,28 +54,6 @@ wheels = [
 ]
 
 [[package]]
-name = "av"
-version = "16.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/cd/3a83ffbc3cc25b39721d174487fb0d51a76582f4a1703f98e46170ce83d4/av-16.1.0.tar.gz", hash = "sha256:a094b4fd87a3721dacf02794d3d2c82b8d712c85b9534437e82a8a978c175ffd", size = 4285203, upload-time = "2026-01-11T07:31:33.772Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/d0/b71b65d1b36520dcb8291a2307d98b7fc12329a45614a303ff92ada4d723/av-16.1.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:e88ad64ee9d2b9c4c5d891f16c22ae78e725188b8926eb88187538d9dd0b232f", size = 26927747, upload-time = "2026-01-09T20:18:16.976Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/79/720a5a6ccdee06eafa211b945b0a450e3a0b8fc3d12922f0f3c454d870d2/av-16.1.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:cb296073fa6935724de72593800ba86ae49ed48af03960a4aee34f8a611f442b", size = 21492232, upload-time = "2026-01-09T20:18:19.266Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/4f/a1ba8d922f2f6d1a3d52419463ef26dd6c4d43ee364164a71b424b5ae204/av-16.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:720edd4d25aa73723c1532bb0597806d7b9af5ee34fc02358782c358cfe2f879", size = 39291737, upload-time = "2026-01-09T20:18:21.513Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/31/fc62b9fe8738d2693e18d99f040b219e26e8df894c10d065f27c6b4f07e3/av-16.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c7f2bc703d0df260a1fdf4de4253c7f5500ca9fc57772ea241b0cb241bcf972e", size = 40846822, upload-time = "2026-01-09T20:18:24.275Z" },
-    { url = "https://files.pythonhosted.org/packages/53/10/ab446583dbce730000e8e6beec6ec3c2753e628c7f78f334a35cad0317f4/av-16.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d69c393809babada7d54964d56099e4b30a3e1f8b5736ca5e27bd7be0e0f3c83", size = 40675604, upload-time = "2026-01-09T20:18:26.866Z" },
-    { url = "https://files.pythonhosted.org/packages/31/d7/1003be685277005f6d63fd9e64904ee222fe1f7a0ea70af313468bb597db/av-16.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:441892be28582356d53f282873c5a951592daaf71642c7f20165e3ddcb0b4c63", size = 42015955, upload-time = "2026-01-09T20:18:29.461Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/4a/fa2a38ee9306bf4579f556f94ecbc757520652eb91294d2a99c7cf7623b9/av-16.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:273a3e32de64819e4a1cd96341824299fe06f70c46f2288b5dc4173944f0fd62", size = 31750339, upload-time = "2026-01-09T20:18:32.249Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/84/2535f55edcd426cebec02eb37b811b1b0c163f26b8d3f53b059e2ec32665/av-16.1.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:640f57b93f927fba8689f6966c956737ee95388a91bd0b8c8b5e0481f73513d6", size = 26945785, upload-time = "2026-01-09T20:18:34.486Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/17/ffb940c9e490bf42e86db4db1ff426ee1559cd355a69609ec1efe4d3a9eb/av-16.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ae3fb658eec00852ebd7412fdc141f17f3ddce8afee2d2e1cf366263ad2a3b35", size = 21481147, upload-time = "2026-01-09T20:18:36.716Z" },
-    { url = "https://files.pythonhosted.org/packages/15/c1/e0d58003d2d83c3921887d5c8c9b8f5f7de9b58dc2194356a2656a45cfdc/av-16.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ee558d9c02a142eebcbe55578a6d817fedfde42ff5676275504e16d07a7f86", size = 39517197, upload-time = "2026-01-11T09:57:31.937Z" },
-    { url = "https://files.pythonhosted.org/packages/32/77/787797b43475d1b90626af76f80bfb0c12cfec5e11eafcfc4151b8c80218/av-16.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7ae547f6d5fa31763f73900d43901e8c5fa6367bb9a9840978d57b5a7ae14ed2", size = 41174337, upload-time = "2026-01-11T09:57:35.792Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ac/d90df7f1e3b97fc5554cf45076df5045f1e0a6adf13899e10121229b826c/av-16.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8cf065f9d438e1921dc31fc7aa045790b58aee71736897866420d80b5450f62a", size = 40817720, upload-time = "2026-01-11T09:57:39.039Z" },
-    { url = "https://files.pythonhosted.org/packages/80/6f/13c3a35f9dbcebafd03fe0c4cbd075d71ac8968ec849a3cfce406c35a9d2/av-16.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a345877a9d3cc0f08e2bc4ec163ee83176864b92587afb9d08dff50f37a9a829", size = 42267396, upload-time = "2026-01-11T09:57:42.115Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/b9/275df9607f7fb44317ccb1d4be74827185c0d410f52b6e2cd770fe209118/av-16.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f49243b1d27c91cd8c66fdba90a674e344eb8eb917264f36117bf2b6879118fd", size = 31752045, upload-time = "2026-01-11T09:57:45.106Z" },
-]
-
-[[package]]
 name = "binaryornot"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -278,28 +256,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ctranslate2"
-version = "4.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pyyaml" },
-    { name = "setuptools" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/25/41920ccee68e91cb6fa0fc9e8078ab2b7839f2c668f750dc123144cb7c6e/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f74200bab9996b14a57cf6f7cb27d0921ceedc4acc1e905598e3e85b4d75b1ec", size = 1256943, upload-time = "2026-02-04T06:11:17.781Z" },
-    { url = "https://files.pythonhosted.org/packages/79/22/bc81fcc9f10ba4da3ffd1a9adec15cfb73cb700b3bbe69c6c8b55d333316/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:59b427eb3ac999a746315b03a63942fddd351f511db82ba1a66880d4dea98e25", size = 11916445, upload-time = "2026-02-04T06:11:19.938Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/a7/494a66bb02c7926331cadfff51d5ce81f5abfb1e8d05d7f2459082f31b48/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95f0c1051c180669d2a83a44b44b518b2d1683de125f623bbc81ad5dd6f6141c", size = 16696997, upload-time = "2026-02-04T06:11:22.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/4e/b48f79fd36e5d3c7e12db383aa49814c340921a618ef7364bd0ced670644/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ed92d9ab0ac6bc7005942be83d68714c80adb0897ab17f98157294ee0374347", size = 38836379, upload-time = "2026-02-04T06:11:26.325Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/23/8c01ac52e1f26fc4dbe985a35222ae7cd365bbf7ee5db5fd5545d8926f91/ctranslate2-4.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:67d9ad9b69933fbfeee7dcec899b2cd9341d5dca4fdfb53e8ba8c109dc332ee1", size = 18843315, upload-time = "2026-02-04T06:11:29.441Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/0f/581de94b64c5f2327a736270bc7e7a5f8fe5cf1ed56a2203b52de4d8986a/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4c0cbd46a23b8dc37ccdbd9b447cb5f7fadc361c90e9df17d82ca84b1f019986", size = 1257089, upload-time = "2026-02-04T06:11:32.442Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e9/d55b0e436362f9fe26bd98fefd2dd5d81926121f1d7f799c805e6035bb26/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:5b141ddad1da5f84cf3c2a569a56227a37de649a555d376cbd9b80e8f0373dd8", size = 11918502, upload-time = "2026-02-04T06:11:33.986Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/ce/9f29f0b0bb4280c2ebafb3ddb6cdff8ef1c2e185ee020c0ec0ecba7dc934/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d00a62544db4a3caaa58a3c50d39b25613c042b430053ae32384d94eb1d40990", size = 16859601, upload-time = "2026-02-04T06:11:36.227Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/86/428d270fd72117d19fb48ed3211aa8a3c8bd7577373252962cb634e0fd01/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:722b93a89647974cbd182b4c7f87fefc7794fff7fc9cbd0303b6447905cc157e", size = 38995338, upload-time = "2026-02-04T06:11:42.789Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/f4/d23dbfb9c62cb642c114a30f05d753ba61d6ffbfd8a3a4012fe85a073bcb/ctranslate2-4.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d0f734dc3757118094663bdaaf713f5090c55c1927fb330a76bb8b84173940e8", size = 18844949, upload-time = "2026-02-04T06:11:45.436Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -322,39 +278,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
-]
-
-[[package]]
-name = "faster-whisper"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "av" },
-    { name = "ctranslate2" },
-    { name = "huggingface-hub" },
-    { name = "onnxruntime" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
-]
-
-[[package]]
-name = "flatbuffers"
-version = "25.12.19"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -443,15 +366,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/72/9bd13836e6525affa132df1b9da04492375632071dc4a50655d79ae23ccd/flet_web-0.81.0.tar.gz", hash = "sha256:4fcc830db6a328d6fcdab0888c92b8ab84a3b551c64345e15738578a422ef845", size = 18311, upload-time = "2026-02-24T18:17:43.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/e5/4ace3353ab3964dad452afec8422999c52d8fdbe59437bc57ce27943006d/flet_web-0.81.0-py3-none-any.whl", hash = "sha256:3369ba89945c18c64d658339b8711026f8dbe3f5ed618a1284c008e4128da6be", size = 23908269, upload-time = "2026-02-24T18:17:44.577Z" },
-]
-
-[[package]]
-name = "fsspec"
-version = "2026.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
 ]
 
 [[package]]
@@ -645,22 +559,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hf-xet"
-version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/cb/9bb543bd987ffa1ee48202cc96a756951b734b79a542335c566148ade36c/hf_xet-1.3.2.tar.gz", hash = "sha256:e130ee08984783d12717444e538587fa2119385e5bd8fc2bb9f930419b73a7af", size = 643646, upload-time = "2026-02-27T17:26:08.051Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/28/dbb024e2e3907f6f3052847ca7d1a2f7a3972fafcd53ff79018977fcb3e4/hf_xet-1.3.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f93b7595f1d8fefddfede775c18b5c9256757824f7f6832930b49858483cd56f", size = 3763961, upload-time = "2026-02-27T17:25:52.537Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/71/b99aed3823c9d1795e4865cf437d651097356a3f38c7d5877e4ac544b8e4/hf_xet-1.3.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:a85d3d43743174393afe27835bde0cd146e652b5fcfdbcd624602daef2ef3259", size = 3526171, upload-time = "2026-02-27T17:25:50.968Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ca/907890ce6ef5598b5920514f255ed0a65f558f820515b18db75a51b2f878/hf_xet-1.3.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7c2a054a97c44e136b1f7f5a78f12b3efffdf2eed3abc6746fc5ea4b39511633", size = 4180750, upload-time = "2026-02-27T17:25:43.125Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ad/bc7f41f87173d51d0bce497b171c4ee0cbde1eed2d7b4216db5d0ada9f50/hf_xet-1.3.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:06b724a361f670ae557836e57801b82c75b534812e351a87a2c739f77d1e0635", size = 3961035, upload-time = "2026-02-27T17:25:41.837Z" },
-    { url = "https://files.pythonhosted.org/packages/73/38/600f4dda40c4a33133404d9fe644f1d35ff2d9babb4d0435c646c63dd107/hf_xet-1.3.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:305f5489d7241a47e0458ef49334be02411d1d0f480846363c1c8084ed9916f7", size = 4161378, upload-time = "2026-02-27T17:26:00.365Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b3/7bc1ff91d1ac18420b7ad1e169b618b27c00001b96310a89f8a9294fe509/hf_xet-1.3.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:06cdbde243c85f39a63b28e9034321399c507bcd5e7befdd17ed2ccc06dfe14e", size = 4398020, upload-time = "2026-02-27T17:26:03.977Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0b/99bfd948a3ed3620ab709276df3ad3710dcea61976918cce8706502927af/hf_xet-1.3.2-cp37-abi3-win_amd64.whl", hash = "sha256:9298b47cce6037b7045ae41482e703c471ce36b52e73e49f71226d2e8e5685a1", size = 3641624, upload-time = "2026-02-27T17:26:13.542Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/02/9a6e4ca1f3f73a164c0cd48e41b3cc56585dcc37e809250de443d673266f/hf_xet-1.3.2-cp37-abi3-win_arm64.whl", hash = "sha256:83d8ec273136171431833a6957e8f3af496bee227a0fe47c7b8b39c106d1749a", size = 3503976, upload-time = "2026-02-27T17:26:12.123Z" },
-]
-
-[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -720,26 +618,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "huggingface-hub"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/7a/304cec37112382c4fe29a43bcb0d5891f922785d18745883d2aa4eb74e4b/huggingface_hub-1.6.0.tar.gz", hash = "sha256:d931ddad8ba8dfc1e816bf254810eb6f38e5c32f60d4184b5885662a3b167325", size = 717071, upload-time = "2026-03-06T14:19:18.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/e3/e3a44f54c8e2f28983fcf07f13d4260b37bd6a0d3a081041bc60b91d230e/huggingface_hub-1.6.0-py3-none-any.whl", hash = "sha256:ef40e2d5cb85e48b2c067020fa5142168342d5108a1b267478ed384ecbf18961", size = 612874, upload-time = "2026-03-06T14:19:16.844Z" },
 ]
 
 [[package]]
@@ -810,7 +688,6 @@ name = "lms-summarizer"
 version = "1.2.1"
 source = { editable = "." }
 dependencies = [
-    { name = "faster-whisper" },
     { name = "flet", extra = ["all"] },
     { name = "google-generativeai" },
     { name = "openai" },
@@ -823,7 +700,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "faster-whisper", specifier = ">=1.1.0" },
     { name = "flet", extras = ["all"], specifier = ">=0.81.0,<1.0" },
     { name = "google-generativeai", specifier = ">=0.8.3" },
     { name = "openai", specifier = ">=1.84.0" },
@@ -883,15 +759,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "mpmath"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -964,30 +831,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
-]
-
-[[package]]
-name = "onnxruntime"
-version = "1.24.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/41/3253db975a90c3ce1d475e2a230773a21cd7998537f0657947df6fb79861/onnxruntime-1.24.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3e6456801c66b095c5cd68e690ca25db970ea5202bd0c5b84a2c3ef7731c5a3c", size = 17332766, upload-time = "2026-03-05T17:18:59.714Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/c5/3af6b325f1492d691b23844d88ed26844c1164620860c5efe95c0e22782d/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b2ebc54c6d8281dccff78d4b06e47d4cf07535937584ab759448390a70f4978", size = 15130330, upload-time = "2026-03-05T16:34:53.831Z" },
-    { url = "https://files.pythonhosted.org/packages/03/4b/f96b46c1866a293ed23ca2cf5e5a63d413ad3a951da60dd877e3c56cbbca/onnxruntime-1.24.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb56575d7794bf0781156955610c9e651c9504c64d42ec880784b6106244882d", size = 17213247, upload-time = "2026-03-05T17:17:59.812Z" },
-    { url = "https://files.pythonhosted.org/packages/36/13/27cf4d8df2578747584e8758aeb0b673b60274048510257f1f084b15e80e/onnxruntime-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:c958222ef9eff54018332beecd32d5d94a3ab079d8821937b333811bf4da0d39", size = 12595530, upload-time = "2026-03-05T17:18:49.356Z" },
-    { url = "https://files.pythonhosted.org/packages/19/8c/6d9f31e6bae72a8079be12ed8ba36c4126a571fad38ded0a1b96f60f6896/onnxruntime-1.24.3-cp311-cp311-win_arm64.whl", hash = "sha256:a8f761857ebaf58a85b9e42422d03207f1d39e6bb8fecfdbf613bac5b9710723", size = 12261715, upload-time = "2026-03-05T17:18:39.699Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
-    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
-    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
 ]
 
 [[package]]
@@ -1364,24 +1207,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "82.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1413,50 +1238,12 @@ wheels = [
 ]
 
 [[package]]
-name = "sympy"
-version = "1.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mpmath" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
-]
-
-[[package]]
-name = "tokenizers"
-version = "0.22.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
-    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
-    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
-    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
-    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
-    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -1469,21 +1256,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -817,6 +817,7 @@ dependencies = [
     { name = "playwright" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
+    { name = "pywhispercpp" },
     { name = "requests" },
 ]
 
@@ -829,6 +830,7 @@ requires-dist = [
     { name = "playwright", specifier = ">=1.52.0" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "pywhispercpp", specifier = ">=1.4.0" },
     { name = "requests", specifier = ">=2.32.3" },
 ]
 
@@ -1014,6 +1016,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
 ]
 
 [[package]]
@@ -1231,6 +1242,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "pywhispercpp"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/7d/fe4b2b190d6cdcf0d5e4ca2b946d73bc449a586606a24d25ff50ffec5a5c/pywhispercpp-1.4.1.tar.gz", hash = "sha256:520ce9275bb6fc81e0daa2e08144a80ee006b117a18058a77860c5b1c9c122f4", size = 1812704, upload-time = "2025-12-30T03:02:12.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/f0/1d34cca9ca25a2cd3f08a965517345d15b9d6fdbab0a5f03756eccad5941/pywhispercpp-1.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bfb8b4095813b97f2c35404ab74cdaaed531a257317a4adbe77833054eec0c6", size = 2206936, upload-time = "2025-12-30T03:01:13.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c7/8d5e5c84d2c2194f6e4b723f1591e6e59f3e46b353109cfa60304ee2d897/pywhispercpp-1.4.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:443a9b85356492d8e9e52e89d705a6a72348d105ac196307de47d845cabebbc4", size = 2377258, upload-time = "2025-12-30T03:01:14.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/96/0481a4f7f88a53ee196afc476b92d3da854b20a5e19c8dfe40e54b95a734/pywhispercpp-1.4.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0b80e56d4be22107a768c44a1f16cc32ed397160e155c31c2d7ec947a326238", size = 2627568, upload-time = "2025-12-30T03:01:16.408Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d9/b23c3a05577a25b5caa71737cd8df4c9d3f60a98118ce91218af58e52c48/pywhispercpp-1.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3eb598e5e1d951efc6d459aaa296755ae0a8408e9e73c1fa5a15982fb682afaf", size = 3283488, upload-time = "2025-12-30T03:01:17.654Z" },
+    { url = "https://files.pythonhosted.org/packages/46/73/ba103a4d93dbd581dd4426a94ca2e94ee4c7a3ec6e9c99d91db8f59cfc2c/pywhispercpp-1.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5af2db687683b7f0d7c6a16382865c32e885210d3c3bdbafd18250ec9f164342", size = 3553466, upload-time = "2025-12-30T03:01:19.064Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fd/7aff54e6705e218ba78a5e99150077b09c5f4fd8e7e09907ed51283fe81d/pywhispercpp-1.4.1-cp311-cp311-win32.whl", hash = "sha256:7225a0e822562da5a9cbaf6186bdc01833f9a11e050c4f2d0bc5f2ccbcfdf560", size = 1040976, upload-time = "2025-12-30T03:01:20.327Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/85/27f74ed67cde89a6b344efad25565c2560931dc924d873dddb48803d666f/pywhispercpp-1.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:1b0a919724237f82ccb5b38866355264eb2c92fc9f744ad89415e880319ed2f6", size = 1221400, upload-time = "2025-12-30T03:01:21.525Z" },
+    { url = "https://files.pythonhosted.org/packages/93/81/a4ca043b96a1cd05659af556223de31ce336f5c88f1decd9ca4def8b8f42/pywhispercpp-1.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92168783736e23e9e274e4496024a7a25d670601a130a35befd627b6f717a98a", size = 2207307, upload-time = "2025-12-30T03:01:22.876Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/7f3f7af598bfaa0fd4836cbd16716a7098c521a76404d5f7bac6211ec725/pywhispercpp-1.4.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed46e7469feaad4a03e25a9f75fe54da791d161489ca02c160540135f21ac481", size = 2378182, upload-time = "2025-12-30T03:01:24.115Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5f/6ad9e807bf705c053a87078aec118f1d154247418a592a2ac0a7622b0539/pywhispercpp-1.4.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aef812596e4726a76c8b5a090d3e4f0ad9e2ebc70f004164ec754a60aaf56446", size = 2630413, upload-time = "2025-12-30T03:01:25.915Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/06/9dac4ebee6fb436650965161082e7de674c68a959fd4ee530cbb231eb4f4/pywhispercpp-1.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b0dd76b28359f7cb82b999627acd4b6a6c1f7aa8106810601d80712d873e3f90", size = 3285003, upload-time = "2025-12-30T03:01:27.676Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/91/72c3b3f85239816d5414b12b190b474e9e7e37472fb0b1cfdff75d42448b/pywhispercpp-1.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8f7f2cd5a0f876134d7ee85c7603e55d0df830ca2e8d910cc11d7e8c0423b739", size = 3556791, upload-time = "2025-12-30T03:01:29.417Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/77/bc7c07353afcf31c81817fcced7a09457aadfe2f825d6243664189955715/pywhispercpp-1.4.1-cp312-cp312-win32.whl", hash = "sha256:dfe69c89c830aad506685c460d5115e6a52159150b86ee2b9a2618e7786767be", size = 1041447, upload-time = "2025-12-30T03:01:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b0/ffcb3e797d80b02e77a174e60f80cd94e851491647e64227ca76b4e2bcf8/pywhispercpp-1.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:4beb57ec35dc0457188470ab4ef673620ce9a49a99ddecd0ae76567986dba908", size = 1222302, upload-time = "2025-12-30T03:01:32.631Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- faster-whisper/CTranslate2를 pywhispercpp(whisper.cpp)로 교체하여 STT 엔진 경량화
- 빌드 용량 813MB → 540MB (33% 감소)
- whisper.cpp는 Apple Silicon Metal 가속 지원, ffmpeg를 통한 WAV 변환 후 처리

## Changes
- `pyproject.toml`: `faster-whisper` → `pywhispercpp` 의존성 교체
- `transcriber.py`: `WhisperTranscriber` 제거, `WhisperCppTranscriber` 단독 사용 (language="ko" 기본)
- `pipeline.py`: 기본 엔진을 `whisper-cpp`로 변경, 항상 WAV 변환 경로 사용
- `file_manager.py`: `get_stt_engine()` → `"whisper-cpp"` 고정
- `lms-summarizer.spec`: CTranslate2/faster-whisper 관련 전부 제거, pywhispercpp 바이너리 수집

## Test plan
- [ ] GUI 전체 파이프라인 동작 확인 (다운로드 → STT → 요약)
- [ ] whisper.cpp 한국어 STT 결과 품질 확인
- [ ] PyInstaller 빌드 `.app` 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)