### PR TITLE
fix: ffmpeg 시스템 의존성 제거 및 Windows 크래시 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@
 ## 설계 의도
 
 - **GUI 중심 개발**: CLI(`src/main.py`)는 폐기 예정. 단, 각 파이프라인 모듈은 독립 실행/테스트 가능하도록 추상화를 유지한다.
-- **기본 엔진**: STT는 faster-whisper(로컬, CTranslate2 기반), 요약은 Gemini. 나머지(ReturnZero, OpenAI, ChatGPT)는 대안 옵션이다.
+- **기본 엔진**: STT는 whisper.cpp(pywhispercpp, ggml 기반), 요약은 Gemini. 나머지(ReturnZero, OpenAI, ChatGPT)는 대안 옵션이다.
 - **ChatGPTSummarizer**: API 호출이 아니라 클립보드 복사 + 브라우저 열기 방식이다. 의도된 동작이다.
-- **Python >=3.11,<3.13**: faster-whisper/onnxruntime 호환성 때문. `.python-version`에 `3.11`로 설정되어 있고 uv가 자동 관리한다.
+- **Python >=3.11,<3.13**: pywhispercpp 호환성 때문. `.python-version`에 `3.11`로 설정되어 있고 uv가 자동 관리한다.
 
 ## 알려진 버그 (미수정)
 
@@ -22,7 +22,7 @@
 ## 배포
 
 - **패키지 매니저**: uv 사용. 의존성 추가는 `uv add`, 설치는 `uv sync`.
-- PyInstaller 빌드 시 faster-whisper(CTranslate2) 포함으로 ~250-350MB.
+- PyInstaller 빌드 시 whisper.cpp(pywhispercpp) + PyAV 포함으로 ~150-200MB.
 - Chrome 경로가 Mac용(`/Applications/Google Chrome.app/...`)으로 하드코딩되어 있다. Windows 배포 시 경로 분기 필요.
 
 ## 커밋 메시지 컨벤션
@@ -44,4 +44,4 @@
 ## 외부 의존성 (시스템 설치 필수)
 
 - `playwright install`: Playwright 브라우저 드라이버 설치가 별도로 필요하다. 단, 내장 Chromium이 아닌 시스템 Chrome을 사용한다.
-- `ffmpeg`: ReturnZero 엔진 사용 시에만 필요 (WAV 변환용). faster-whisper는 PyAV를 내장하므로 불필요.
+- `ffmpeg`: 불필요. PyAV(`av` 패키지)를 사용하여 MP4→WAV 변환을 처리한다. 시스템 ffmpeg 설치 없이 동작한다.

--- a/build_mac_pyinstaller.sh
+++ b/build_mac_pyinstaller.sh
@@ -23,21 +23,6 @@ if ! command -v uv &> /dev/null; then
     exit 1
 fi
 
-# ffmpeg 확인
-FFMPEG_PATH=""
-for path in "/opt/homebrew/bin/ffmpeg" "/usr/local/bin/ffmpeg" "/usr/bin/ffmpeg"; do
-    if [ -f "$path" ]; then
-        FFMPEG_PATH="$path"
-        break
-    fi
-done
-if [ -z "$FFMPEG_PATH" ]; then
-    echo "❌ ffmpeg를 찾을 수 없습니다."
-    echo "   설치: brew install ffmpeg"
-    exit 1
-fi
-echo "✅ ffmpeg: $FFMPEG_PATH"
-
 # Whisper 모델 사전 다운로드 (base 모델 ~142MB)
 echo "📥 Whisper base 모델 확인 중..."
 uv run python -c "from pywhispercpp.model import Model; Model('base'); print('✅ 모델 준비 완료')"

--- a/lms-summarizer.spec
+++ b/lms-summarizer.spec
@@ -104,7 +104,7 @@ a = Analysis(
         # torch (불필요)
         "torch", "torch._C", "torch.nn", "torch.backends",
         # faster-whisper / CTranslate2 (whisper.cpp로 대체)
-        "faster_whisper", "ctranslate2", "tokenizers", "huggingface_hub", "av",
+        "faster_whisper", "ctranslate2", "tokenizers", "huggingface_hub",
         # PyQt5 (더 이상 사용하지 않음)
         "PyQt5", "PyQt5.QtCore", "PyQt5.QtWidgets", "PyQt5.QtGui",
         "qtawesome",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "flet[all]>=0.81.0,<1.0",
     "python-dotenv>=1.1.0",
     "requests>=2.32.3",
+    "av>=13.0.0",
 ]
 
 [project.scripts]

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -4,7 +4,6 @@
 # 사전 요구사항:
 #   - Python 3.9-3.12 설치 (python.org)
 #   - uv 설치: winget install astral-sh.uv
-#   - ffmpeg 설치: winget install Gyan.FFmpeg (또는 PATH에 추가)
 
 $ErrorActionPreference = "Stop"
 
@@ -25,25 +24,6 @@ if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
     Write-Host "   설치: winget install astral-sh.uv" -ForegroundColor Yellow
     exit 1
 }
-
-# ffmpeg 확인
-$ffmpegPath = (Get-Command ffmpeg -ErrorAction SilentlyContinue)?.Source
-if (-not $ffmpegPath) {
-    $candidates = @(
-        "$env:LOCALAPPDATA\Microsoft\WinGet\Links\ffmpeg.exe",
-        "C:\ffmpeg\bin\ffmpeg.exe",
-        "C:\Program Files\ffmpeg\bin\ffmpeg.exe"
-    )
-    foreach ($c in $candidates) {
-        if (Test-Path $c) { $ffmpegPath = $c; break }
-    }
-}
-if (-not $ffmpegPath) {
-    Write-Host "❌ ffmpeg를 찾을 수 없습니다." -ForegroundColor Red
-    Write-Host "   설치: winget install Gyan.FFmpeg" -ForegroundColor Yellow
-    exit 1
-}
-Write-Host "✅ ffmpeg: $ffmpegPath" -ForegroundColor Green
 
 # Whisper 모델 사전 다운로드
 Write-Host "📥 Whisper base 모델 확인 중..."

--- a/src/audio_pipeline/converter.py
+++ b/src/audio_pipeline/converter.py
@@ -1,15 +1,34 @@
-import subprocess
 import os
+import av
+
 
 def convert_mp4_to_wav(mp4_path: str, wav_path: str, sample_rate: int = 16000):
-    # 독립적으로 mp4를 wav로 변환하는 함수
+    # PyAV를 사용하여 MP4에서 오디오를 추출, mono WAV로 변환
     if not os.path.exists(mp4_path):
         raise FileNotFoundError(f"입력 파일이 존재하지 않음: {mp4_path}")
-    
-    command = [
-        "ffmpeg", "-i", mp4_path,
-        "-ac", "1", "-ar", str(sample_rate), "-vn", wav_path, "-y"
-    ]
-    result = subprocess.run(command, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(f"FFmpeg 오류: {result.stderr}")
+
+    try:
+        input_container = av.open(mp4_path)
+        output_container = av.open(wav_path, mode='w')
+
+        if not input_container.streams.audio:
+            raise RuntimeError(f"오디오 스트림이 없음: {mp4_path}")
+
+        output_stream = output_container.add_stream('pcm_s16le', rate=sample_rate)
+        output_stream.layout = 'mono'
+
+        resampler = av.AudioResampler(format='s16', layout='mono', rate=sample_rate)
+
+        for frame in input_container.decode(audio=0):
+            for resampled in resampler.resample(frame):
+                for packet in output_stream.encode(resampled):
+                    output_container.mux(packet)
+
+        # 인코더 버퍼 플러시
+        for packet in output_stream.encode(None):
+            output_container.mux(packet)
+
+        output_container.close()
+        input_container.close()
+    except av.AVError as e:
+        raise RuntimeError(f"오디오 변환 오류: {e}")

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -6,6 +6,17 @@ import os
 import sys
 
 
+def fix_windowed_stdio():
+    """Windows PyInstaller windowed 모드(console=False)에서 sys.stdout/stderr가 None이 되는 문제 방지"""
+    if sys.stdout is None:
+        sys.stdout = open(os.devnull, 'w')
+    if sys.stderr is None:
+        sys.stderr = open(os.devnull, 'w')
+
+
+fix_windowed_stdio()
+
+
 def setup_import_path():
     """개발 환경과 PyInstaller 환경 모두에서 동작하도록 import 경로 설정"""
     if getattr(sys, 'frozen', False):

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,28 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "16.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/cd/3a83ffbc3cc25b39721d174487fb0d51a76582f4a1703f98e46170ce83d4/av-16.1.0.tar.gz", hash = "sha256:a094b4fd87a3721dacf02794d3d2c82b8d712c85b9534437e82a8a978c175ffd", size = 4285203, upload-time = "2026-01-11T07:31:33.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/d0/b71b65d1b36520dcb8291a2307d98b7fc12329a45614a303ff92ada4d723/av-16.1.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:e88ad64ee9d2b9c4c5d891f16c22ae78e725188b8926eb88187538d9dd0b232f", size = 26927747, upload-time = "2026-01-09T20:18:16.976Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/79/720a5a6ccdee06eafa211b945b0a450e3a0b8fc3d12922f0f3c454d870d2/av-16.1.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:cb296073fa6935724de72593800ba86ae49ed48af03960a4aee34f8a611f442b", size = 21492232, upload-time = "2026-01-09T20:18:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4f/a1ba8d922f2f6d1a3d52419463ef26dd6c4d43ee364164a71b424b5ae204/av-16.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:720edd4d25aa73723c1532bb0597806d7b9af5ee34fc02358782c358cfe2f879", size = 39291737, upload-time = "2026-01-09T20:18:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/31/fc62b9fe8738d2693e18d99f040b219e26e8df894c10d065f27c6b4f07e3/av-16.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c7f2bc703d0df260a1fdf4de4253c7f5500ca9fc57772ea241b0cb241bcf972e", size = 40846822, upload-time = "2026-01-09T20:18:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/53/10/ab446583dbce730000e8e6beec6ec3c2753e628c7f78f334a35cad0317f4/av-16.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d69c393809babada7d54964d56099e4b30a3e1f8b5736ca5e27bd7be0e0f3c83", size = 40675604, upload-time = "2026-01-09T20:18:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d7/1003be685277005f6d63fd9e64904ee222fe1f7a0ea70af313468bb597db/av-16.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:441892be28582356d53f282873c5a951592daaf71642c7f20165e3ddcb0b4c63", size = 42015955, upload-time = "2026-01-09T20:18:29.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4a/fa2a38ee9306bf4579f556f94ecbc757520652eb91294d2a99c7cf7623b9/av-16.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:273a3e32de64819e4a1cd96341824299fe06f70c46f2288b5dc4173944f0fd62", size = 31750339, upload-time = "2026-01-09T20:18:32.249Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/84/2535f55edcd426cebec02eb37b811b1b0c163f26b8d3f53b059e2ec32665/av-16.1.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:640f57b93f927fba8689f6966c956737ee95388a91bd0b8c8b5e0481f73513d6", size = 26945785, upload-time = "2026-01-09T20:18:34.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/17/ffb940c9e490bf42e86db4db1ff426ee1559cd355a69609ec1efe4d3a9eb/av-16.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ae3fb658eec00852ebd7412fdc141f17f3ddce8afee2d2e1cf366263ad2a3b35", size = 21481147, upload-time = "2026-01-09T20:18:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c1/e0d58003d2d83c3921887d5c8c9b8f5f7de9b58dc2194356a2656a45cfdc/av-16.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ee558d9c02a142eebcbe55578a6d817fedfde42ff5676275504e16d07a7f86", size = 39517197, upload-time = "2026-01-11T09:57:31.937Z" },
+    { url = "https://files.pythonhosted.org/packages/32/77/787797b43475d1b90626af76f80bfb0c12cfec5e11eafcfc4151b8c80218/av-16.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7ae547f6d5fa31763f73900d43901e8c5fa6367bb9a9840978d57b5a7ae14ed2", size = 41174337, upload-time = "2026-01-11T09:57:35.792Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/d90df7f1e3b97fc5554cf45076df5045f1e0a6adf13899e10121229b826c/av-16.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8cf065f9d438e1921dc31fc7aa045790b58aee71736897866420d80b5450f62a", size = 40817720, upload-time = "2026-01-11T09:57:39.039Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6f/13c3a35f9dbcebafd03fe0c4cbd075d71ac8968ec849a3cfce406c35a9d2/av-16.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a345877a9d3cc0f08e2bc4ec163ee83176864b92587afb9d08dff50f37a9a829", size = 42267396, upload-time = "2026-01-11T09:57:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b9/275df9607f7fb44317ccb1d4be74827185c0d410f52b6e2cd770fe209118/av-16.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f49243b1d27c91cd8c66fdba90a674e344eb8eb917264f36117bf2b6879118fd", size = 31752045, upload-time = "2026-01-11T09:57:45.106Z" },
+]
+
+[[package]]
 name = "binaryornot"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -688,6 +710,7 @@ name = "lms-summarizer"
 version = "1.4.1"
 source = { editable = "." }
 dependencies = [
+    { name = "av" },
     { name = "flet", extra = ["all"] },
     { name = "google-generativeai" },
     { name = "openai" },
@@ -700,6 +723,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "av", specifier = ">=13.0.0" },
     { name = "flet", extras = ["all"], specifier = ">=0.81.0,<1.0" },
     { name = "google-generativeai", specifier = ">=0.8.3" },
     { name = "openai", specifier = ">=1.84.0" },


### PR DESCRIPTION
## Summary
- **Mac**: `subprocess.run("ffmpeg")` → PyAV(`av`) 라이브러리로 교체하여 PyInstaller 번들에서 ffmpeg을 못 찾는 문제 해결
- **Windows**: `console=False` 빌드에서 `sys.stdout=None`으로 인한 `print()` 크래시 수정
- 빌드 스크립트/문서에서 ffmpeg 시스템 의존성 제거

## 원인 분석

### Mac (`No such file or directory: 'ffmpeg'`)
macOS `.app` 번들은 Finder에서 실행 시 제한된 PATH(`/usr/bin:/bin`)만 가짐. Homebrew ffmpeg(`/opt/homebrew/bin`)이 PATH에 없어서 subprocess 호출 실패. PyInstaller 결함이 아니라 OS 앱 번들 실행 환경 특성.

### Windows (`'NoneType' object has no attribute 'write'`)
PyInstaller `console=False`로 빌드된 Windows 앱은 `sys.stdout`/`sys.stderr`가 `None`이 됨. 오디오 파이프라인의 `print()` 호출 시 `None.write()` AttributeError 발생.

## 변경 파일
- `src/audio_pipeline/converter.py` — subprocess ffmpeg → PyAV API
- `src/gui/main.py` — Windows stdout/stderr None 가드
- `pyproject.toml` — `av>=13.0.0` 의존성 추가
- `lms-summarizer.spec` — excludes에서 `av` 제거
- `build_mac_pyinstaller.sh` — ffmpeg 시스템 체크 제거
- `scripts/build_windows.ps1` — ffmpeg 시스템 체크 제거
- `CLAUDE.md` — 엔진/의존성 설명 업데이트

## Test plan
- [ ] 로컬에서 PyAV 변환 테스트 (MP4 → WAV)
- [ ] Mac PyInstaller 빌드 후 전체 파이프라인 실행
- [ ] Windows PyInstaller 빌드 후 전체 파이프라인 실행
- [ ] CI release workflow 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)