### PR TITLE
build: Mac 빌드 용량 최적화 (~375MB 절감)

### DIFF
--- a/lms-summarizer.spec
+++ b/lms-summarizer.spec
@@ -101,8 +101,12 @@ a = Analysis(
         "tkinter", "matplotlib", "PIL", "Pillow",
         "scipy", "pandas", "notebook", "jupyter",
         "IPython", "cv2", "sklearn",
-        # torch (불필요)
+        # torch 및 관련 (~275MB 절감)
         "torch", "torch._C", "torch.nn", "torch.backends",
+        "torch.cuda", "torch.distributed", "torch.utils",
+        "torchvision", "torchaudio", "caffe2",
+        # numba / llvmlite (~100MB 절감)
+        "numba", "llvmlite",
         # faster-whisper / CTranslate2 (whisper.cpp로 대체)
         "faster_whisper", "ctranslate2", "tokenizers", "huggingface_hub",
         # PyQt5 (더 이상 사용하지 않음)
@@ -134,6 +138,16 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
 )
+
+# 불필요한 대용량 네이티브 라이브러리 필터링 (excludes는 Python 모듈만 차단)
+_bloat_prefixes = ('torch', 'libtorch', 'numba', 'llvmlite', 'caffe2')
+
+def _is_bloat(name):
+    parts = name.replace('\\', '/').split('/')
+    return any(p.startswith(_bloat_prefixes) for p in parts)
+
+a.binaries = [b for b in a.binaries if not _is_bloat(b[0])]
+a.datas = [d for d in a.datas if not _is_bloat(d[0])]
 
 coll = COLLECT(
     exe,


### PR DESCRIPTION
## Summary
- Mac 빌드 403MB → ~150MB 예상 (Windows 164MB와 동등)
- PyInstaller `excludes`가 네이티브 바이너리(`.dylib`)를 차단하지 못하는 문제를 바이너리/데이터 레벨 필터링으로 해결

## 원인
torch(~275MB), llvmlite(~87MB), numba(~13MB)가 Mac 빌드에만 간접 의존성으로 번들링됨. 이 프로젝트에서는 사용하지 않는 패키지들.

## 변경
- `lms-summarizer.spec`: excludes 강화 + `a.binaries`/`a.datas` 필터링 추가

## Test plan
- [ ] Mac PyInstaller 빌드 후 ZIP 용량 확인 (~150MB 이하)
- [ ] 빌드된 앱 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)