### PR TITLE
fix: 로그인 실패 감지 개선 (URL/DOM 하이브리드 + UI 피드백)

### DIFF
--- a/src/gui/components/input_field.py
+++ b/src/gui/components/input_field.py
@@ -113,5 +113,13 @@ class InputField:
         if self.config.is_password:
             self._korean_warning.visible = False
 
+    def set_error(self, error_text: str = None):
+        """에러 상태 설정"""
+        self.control.error_text = error_text
+
+    def clear_error(self):
+        """에러 상태 해제"""
+        self.control.error_text = None
+
     def set_enabled(self, enabled: bool):
         self.control.disabled = not enabled

--- a/src/gui/views/main_view.py
+++ b/src/gui/views/main_view.py
@@ -339,6 +339,10 @@ class MainView:
             self._handle_stop()
             return
 
+        # 이전 에러 상태 초기화
+        for key in self.input_fields:
+            self.input_fields[key].clear_error()
+
         inputs = {name: field.get_value() for name, field in self.input_fields.items()}
         valid, error_message = InputValidator.validate_all_inputs(inputs)
         if not valid:
@@ -408,6 +412,18 @@ class MainView:
 
                 if success:
                     self._show_snackbar("작업이 완료되었습니다!", Colors.SUCCESS)
+                elif message and message.startswith("login_failed:"):
+                    parts = message.split(":", 2)
+                    reason = parts[1] if len(parts) > 1 else "unknown"
+                    display_msg = parts[2] if len(parts) > 2 else message
+
+                    self._show_snackbar(display_msg, Colors.ERROR)
+
+                    if reason == "invalid_credentials":
+                        self.input_fields['student_id'].set_error("학번을 확인하세요")
+                        self.input_fields['password'].set_error("비밀번호를 확인하세요")
+                    elif reason in ("navigation_timeout", "sso_page_failed"):
+                        self.input_fields['student_id'].set_error("로그인 서버 연결 실패")
                 elif "취소" not in message:
                     self._show_snackbar(f"오류: {message}", Colors.ERROR)
                 else:

--- a/src/gui/workers/course_list_worker.py
+++ b/src/gui/workers/course_list_worker.py
@@ -9,6 +9,7 @@ from typing import Optional, Callable, List
 
 from src.gui.config.course_models import Course
 from src.gui.core.file_manager import get_chrome_path, get_debug_mode
+from src.video_pipeline.login import LoginFailedError
 
 
 class CourseListWorker:
@@ -66,6 +67,9 @@ class CourseListWorker:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             loop.run_until_complete(self._async_run())
+        except LoginFailedError as e:
+            if not self._cancel_event.is_set():
+                self._on_error(f"로그인 실패: {e.detail}")
         except Exception as e:
             if not self._cancel_event.is_set():
                 self._on_error(str(e))

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Callable, Optional
 
 from src.gui.config.constants import Messages
+from src.video_pipeline.login import LoginFailedError
 from src.gui.core.file_manager import (
     create_config_files, extract_urls_from_input, ensure_downloads_directory,
     get_summary_prompt, get_chrome_path, get_debug_mode, get_stt_engine,
@@ -119,6 +120,11 @@ class ProcessingWorker:
         except CancelledException:
             self._emit_log("⚠️ 사용자에 의해 작업이 취소되었습니다.")
             self._on_finished(False, "작업이 취소되었습니다.")
+
+        except LoginFailedError as e:
+            reason_msg = e.detail
+            self._emit_log(f"로그인 실패: {reason_msg}")
+            self._on_finished(False, f"login_failed:{e.reason}:{reason_msg}")
 
         except Exception as e:
             error_msg = f"작업 중 오류 발생: {str(e)}"

--- a/src/video_pipeline/course_scraper.py
+++ b/src/video_pipeline/course_scraper.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Callable
 
 from playwright.async_api import async_playwright, Playwright, Page, Frame
 
-from src.video_pipeline.login import perform_login_if_needed
+from src.video_pipeline.login import perform_login_if_needed, LoginFailedError
 from src.gui.config.course_models import (
     Course, LectureItem, Week, CourseDetail,
     LectureType, VIDEO_LECTURE_TYPES,
@@ -95,11 +95,9 @@ class CourseScraper:
 
         if "login" in self._page.url:
             self._log("로그인 진행 중...")
-            result = await perform_login_if_needed(
+            await perform_login_if_needed(
                 self._page, self.username, self.password
             )
-            if not result:
-                raise RuntimeError("LMS 로그인 실패. 학번/비밀번호를 확인하세요.")
             self._log("로그인 완료")
         else:
             self._log("이미 로그인 상태")

--- a/src/video_pipeline/login.py
+++ b/src/video_pipeline/login.py
@@ -1,6 +1,14 @@
 from typing import Callable, Optional
 
-from playwright.async_api import Page
+from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
+
+
+class LoginFailedError(Exception):
+    """로그인 실패 시 발생하는 예외"""
+    def __init__(self, reason: str, detail: str):
+        self.reason = reason  # "invalid_credentials", "sso_page_failed", "navigation_timeout", "unknown"
+        self.detail = detail  # Human-readable Korean message
+        super().__init__(detail)
 
 
 async def perform_login_if_needed(
@@ -30,20 +38,36 @@ async def perform_login_if_needed(
         await page.locator("input#pwd").fill(password)
 
         _log("[LOGIN] 로그인 버튼 클릭")
-        async with page.expect_navigation(wait_until="networkidle"):
-            await page.locator("a.btn_login").click()
+        try:
+            async with page.expect_navigation(wait_until="networkidle"):
+                await page.locator("a.btn_login").click()
+        except PlaywrightTimeoutError:
+            raise LoginFailedError("navigation_timeout", "로그인 서버 응답 시간이 초과되었습니다.")
 
         _log(f"[LOGIN] 리디렉션 완료. URL: {page.url}")
 
+        # DOM 기반 에러 감지
+        error_el = await page.query_selector(
+            ".error-message, .msg_error, .alert-danger, .login_error, #login_error_msg"
+        )
+        if error_el:
+            error_text = (await error_el.inner_text()).strip()
+            _log(f"[LOGIN] 로그인 실패 (DOM 에러): {error_text}")
+            raise LoginFailedError("invalid_credentials", error_text or "아이디 또는 비밀번호가 올바르지 않습니다.")
+
+        # URL 기반 에러 감지
         if "login" in page.url:
             _log("[LOGIN] 로그인 실패. 아이디/비밀번호 확인 필요.")
-            return False
+            raise LoginFailedError("invalid_credentials", "아이디 또는 비밀번호가 올바르지 않습니다.")
 
         await page.wait_for_load_state("networkidle")
         _log(f"[LOGIN] 최종 페이지 로드 완료. URL: {page.url}")
 
         return True
 
+    except LoginFailedError:
+        raise
+
     except Exception as e:
         _log(f"[LOGIN] 예외 발생: {type(e).__name__}: {e}")
-        return False
+        raise LoginFailedError("unknown", f"로그인 중 예기치 않은 오류가 발생했습니다: {e}")

--- a/src/video_pipeline/pipeline.py
+++ b/src/video_pipeline/pipeline.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from playwright.async_api import async_playwright, Playwright, Page
 from typing import Callable, Optional, Tuple
 
-from src.video_pipeline.login import perform_login_if_needed
+from src.video_pipeline.login import perform_login_if_needed, LoginFailedError
 from src.video_pipeline.video_parser import extract_video_url
 from src.video_pipeline.download_video import download_video
 from src.user_setting import UserSetting
@@ -78,11 +78,9 @@ class VideoPipeline:
 
         if "login" in page.url:
             self._log("로그인 진행 중...")
-            result = await perform_login_if_needed(
+            await perform_login_if_needed(
                 page, self.user_id, self.password, log=self._log
             )
-            if not result:
-                raise RuntimeError("LMS 로그인 실패. 학번/비밀번호를 확인하세요.")
             self._log("로그인 완료")
         else:
             self._log("이미 로그인 상태")


### PR DESCRIPTION
## Summary
- `LoginFailedError` 예외 클래스 도입 (`reason` + `detail` 구조화)
- 로그인 후 URL + DOM 하이브리드 실패 감지 (에러 메시지 요소 탐색, URL 체크)
- `return False` → `raise LoginFailedError`로 변경하여 예외 전파 단순화
- 로그인 실패 시 학번/비밀번호 입력란에 에러 표시 + 스낵바 피드백
- 강의 목록 조회 시에도 동일한 로그인 실패 감지 적용

## Changes
- `src/video_pipeline/login.py` - LoginFailedError 예외, 하이브리드 감지 로직
- `src/video_pipeline/pipeline.py` - 예외 전파 단순화
- `src/video_pipeline/course_scraper.py` - 예외 전파 단순화
- `src/gui/components/input_field.py` - set_error/clear_error 메서드
- `src/gui/workers/processing_worker.py` - LoginFailedError 핸들링
- `src/gui/workers/course_list_worker.py` - LoginFailedError 핸들링
- `src/gui/views/main_view.py` - 로그인 실패 UI 피드백

## Test plan
- [ ] 잘못된 학번/비밀번호로 로그인 시 에러 메시지가 표시되는지 확인
- [ ] 학번/비밀번호 입력란에 빨간색 에러 테두리가 표시되는지 확인
- [ ] 다시 시작 시 에러 상태가 초기화되는지 확인
- [ ] 정상 로그인이 기존처럼 동작하는지 확인
- [ ] 강의 목록 조회에서도 로그인 실패 감지가 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)