### PR TITLE
feat: 파이프라인 중간 단계 재시작 기능

### DIFF
--- a/src/audio_pipeline/pipeline.py
+++ b/src/audio_pipeline/pipeline.py
@@ -11,27 +11,50 @@ class AudioToTextPipeline:
         self.engine = engine
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
 
-    def process(self, mp4_path: str, remove_wav: bool = True) -> str:
-        if not mp4_path.endswith(".mp4"):
-            raise ValueError("mp4 파일만 처리 가능합니다.")
+    def convert_to_wav(self, mp4_path: str) -> str:
+        """MP4 파일을 WAV로 변환하고 WAV 경로를 반환"""
+        from src.audio_pipeline.converter import convert_mp4_to_wav
 
         filename = Path(mp4_path).stem
+        wav_path = os.path.join(self.downloads_dir, f"{filename}.wav")
+
+        print(f"[INFO] WAV 변환 시작: {mp4_path}")
+        start_time = time.time()
+        convert_mp4_to_wav(mp4_path, wav_path, self.sample_rate)
+        elapsed = time.time() - start_time
+        print(f"[DONE] WAV 변환 완료: {wav_path} ({elapsed:.1f}초)")
+
+        return wav_path
+
+    def transcribe(self, wav_path: str, remove_wav: bool = True) -> str:
+        """WAV 파일을 텍스트로 변환하고 텍스트 파일 경로를 반환"""
+        filename = Path(wav_path).stem
         txt_path = os.path.join(self.downloads_dir, f"{filename}.txt")
 
-        print(f"[INFO] 변환 시작: {mp4_path}")
+        print(f"[INFO] STT 변환 시작: {wav_path}")
         start_time = time.time()
-
-        # whisper.cpp, ReturnZero 모두 WAV 입력 필요
-        from src.audio_pipeline.converter import convert_mp4_to_wav
-        wav_path = os.path.join(self.downloads_dir, f"{filename}.wav")
-        convert_mp4_to_wav(mp4_path, wav_path, self.sample_rate)
         transcribe_audio_to_text(wav_path, txt_path, engine=self.engine)
+        elapsed = time.time() - start_time
+        print(f"[DONE] 텍스트 저장 완료: {txt_path} ({elapsed:.1f}초)")
+
         if remove_wav:
             os.remove(wav_path)
             print(f"[INFO] 임시 파일 삭제됨: {wav_path}")
 
+        return txt_path
+
+    def process(self, mp4_path: str, remove_wav: bool = True) -> str:
+        """MP4 → WAV → 텍스트 전체 파이프라인 (하위 호환성 유지)"""
+        if not mp4_path.endswith(".mp4"):
+            raise ValueError("mp4 파일만 처리 가능합니다.")
+
+        print(f"[INFO] 변환 시작: {mp4_path}")
+        start_time = time.time()
+
+        wav_path = self.convert_to_wav(mp4_path)
+        txt_path = self.transcribe(wav_path, remove_wav=remove_wav)
+
         end_time = time.time()
-        print(f"[DONE] 텍스트 저장 완료: {txt_path}")
         print(f"[INFO] 총 소요 시간: {end_time - start_time:.1f}초")
 
         return txt_path

--- a/src/gui/components/stage_selector.py
+++ b/src/gui/components/stage_selector.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import flet as ft
 
 from src.gui.theme import Colors, Typography, Radius, Spacing
+from src.gui.core.file_manager import ensure_downloads_directory
+from src.gui.core.artifact_detector import ArtifactDetector
 from src.pipeline_stage import PipelineStage, STAGE_LABELS
 
 # 각 단계에서 입력으로 받을 파일 확장자
@@ -66,6 +68,27 @@ class StageSelector:
             ),
         )
 
+        # 자동 감지 버튼
+        self._auto_detect_btn = ft.OutlinedButton(
+            content=ft.Text("자동 감지"),
+            icon=ft.Icons.SEARCH,
+            on_click=self._handle_auto_detect,
+            style=ft.ButtonStyle(
+                color=Colors.TEXT_SECONDARY,
+                shape=ft.RoundedRectangleBorder(radius=Radius.SM),
+                padding=ft.padding.symmetric(horizontal=12, vertical=6),
+                text_style=ft.TextStyle(size=Typography.CAPTION),
+            ),
+        )
+
+        # 자동 감지 결과 메시지
+        self._detect_info = ft.Text(
+            "",
+            size=Typography.SMALL,
+            color=Colors.INFO,
+            visible=False,
+        )
+
         # 선택된 파일 목록 표시
         self._file_list = ft.Column(
             controls=[],
@@ -86,12 +109,20 @@ class StageSelector:
 
         self.control = ft.Column(
             controls=[
-                self._dropdown,
+                ft.Row(
+                    controls=[
+                        ft.Container(content=self._dropdown, expand=True),
+                        self._auto_detect_btn,
+                    ],
+                    spacing=Spacing.SM,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                ),
                 ft.Row(
                     controls=[self._pick_btn, self._file_count_text],
                     spacing=Spacing.SM,
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
+                self._detect_info,
                 self._file_list,
             ],
             spacing=Spacing.XS,
@@ -102,20 +133,49 @@ class StageSelector:
         stage = self.get_stage()
         show_picker = stage != PipelineStage.DOWNLOAD
         self._pick_btn.visible = show_picker
-        # 단계 변경 시 파일 목록 초기화
+        # 단계 변경 시 파일 목록 및 감지 메시지 초기화
         self._selected_files.clear()
         self._file_list.controls.clear()
         self._file_list.visible = False
         self._file_count_text.visible = False
         self._file_count_text.value = ""
+        self._detect_info.visible = False
+        self._detect_info.value = ""
 
         if self._pick_btn.page:
-            self._pick_btn.update()
-            self._file_list.update()
-            self._file_count_text.update()
+            self._pick_btn.page.update()
 
         if self._on_change:
             self._on_change(stage)
+
+    def _handle_auto_detect(self, e):
+        """다운로드 디렉토리를 스캔하여 시작 단계와 파일을 자동 설정"""
+        downloads_dir = ensure_downloads_directory()
+        detector = ArtifactDetector(downloads_dir)
+        recommended_stage, files = detector.recommend_start_stage()
+
+        if recommended_stage == PipelineStage.DOWNLOAD and not files:
+            self._detect_info.value = "감지된 산출물이 없습니다. 1단계부터 시작합니다."
+            self._detect_info.color = Colors.TEXT_MUTED
+            self._detect_info.visible = True
+            self.set_stage(PipelineStage.DOWNLOAD)
+            self._selected_files.clear()
+            self._file_list.controls.clear()
+            self._file_list.visible = False
+            self._file_count_text.visible = False
+            self._pick_btn.visible = False
+        else:
+            self.set_stage(recommended_stage)
+            self.set_files(files)
+            stage_name = STAGE_LABELS[recommended_stage]
+            self._detect_info.value = (
+                f"{len(files)}개 파일 감지 → {recommended_stage.value}단계: {stage_name}부터 시작"
+            )
+            self._detect_info.color = Colors.INFO
+            self._detect_info.visible = True
+
+        if self._detect_info.page:
+            self._detect_info.page.update()
 
     def _handle_pick_files(self, e):
         stage = self.get_stage()
@@ -205,6 +265,7 @@ class StageSelector:
         """활성/비활성 설정"""
         self._dropdown.disabled = not enabled
         self._pick_btn.disabled = not enabled
+        self._auto_detect_btn.disabled = not enabled
 
     def get_files(self) -> list[str]:
         """선택된 입력 파일 목록 반환"""

--- a/src/gui/components/stage_selector.py
+++ b/src/gui/components/stage_selector.py
@@ -2,14 +2,29 @@
 Flet 기반 파이프라인 시작 단계 선택기
 """
 
+from pathlib import Path
+
 import flet as ft
 
 from src.gui.theme import Colors, Typography, Radius, Spacing
 from src.pipeline_stage import PipelineStage, STAGE_LABELS
 
+# 각 단계에서 입력으로 받을 파일 확장자
+_STAGE_INPUT_EXTENSIONS = {
+    PipelineStage.CONVERT_AUDIO: [".mp4", ".ts"],
+    PipelineStage.STT: [".wav", ".mp3"],
+    PipelineStage.SUMMARIZE: [".txt"],
+}
+
+_STAGE_ALLOWED_EXTENSIONS = {
+    PipelineStage.CONVERT_AUDIO: ["mp4", "ts"],
+    PipelineStage.STT: ["wav", "mp3"],
+    PipelineStage.SUMMARIZE: ["txt"],
+}
+
 
 class StageSelector:
-    """파이프라인 시작 단계 선택 드롭다운"""
+    """파이프라인 시작 단계 선택 드롭다운 + 파일 선택기"""
 
     def __init__(self, on_change=None):
         self._on_change = on_change
@@ -37,15 +52,141 @@ class StageSelector:
             dense=True,
         )
 
+        # 파일 선택 버튼
+        self._pick_btn = ft.OutlinedButton(
+            content=ft.Text("파일 선택"),
+            icon=ft.Icons.ATTACH_FILE,
+            on_click=self._handle_pick_files,
+            visible=False,
+            style=ft.ButtonStyle(
+                color=Colors.PRIMARY,
+                shape=ft.RoundedRectangleBorder(radius=Radius.SM),
+                padding=ft.padding.symmetric(horizontal=12, vertical=6),
+                text_style=ft.TextStyle(size=Typography.CAPTION),
+            ),
+        )
+
+        # 선택된 파일 목록 표시
+        self._file_list = ft.Column(
+            controls=[],
+            spacing=2,
+            visible=False,
+        )
+
+        # 파일 개수 요약 텍스트
+        self._file_count_text = ft.Text(
+            "",
+            size=Typography.CAPTION,
+            color=Colors.TEXT_SECONDARY,
+            visible=False,
+        )
+
+        # FilePicker (page overlay에 등록 필요)
+        self.file_picker = ft.FilePicker(on_result=self._on_files_selected)
+
         self.control = ft.Column(
-            controls=[self._dropdown],
+            controls=[
+                self._dropdown,
+                ft.Row(
+                    controls=[self._pick_btn, self._file_count_text],
+                    spacing=Spacing.SM,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                ),
+                self._file_list,
+            ],
             spacing=Spacing.XS,
             horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
         )
 
     def _handle_change(self, e):
+        stage = self.get_stage()
+        show_picker = stage != PipelineStage.DOWNLOAD
+        self._pick_btn.visible = show_picker
+        # 단계 변경 시 파일 목록 초기화
+        self._selected_files.clear()
+        self._file_list.controls.clear()
+        self._file_list.visible = False
+        self._file_count_text.visible = False
+        self._file_count_text.value = ""
+
+        if self._pick_btn.page:
+            self._pick_btn.update()
+            self._file_list.update()
+            self._file_count_text.update()
+
         if self._on_change:
-            self._on_change(self.get_stage())
+            self._on_change(stage)
+
+    def _handle_pick_files(self, e):
+        stage = self.get_stage()
+        allowed = _STAGE_ALLOWED_EXTENSIONS.get(stage, [])
+        file_type = ft.FilePickerFileType.CUSTOM if allowed else ft.FilePickerFileType.ANY
+        self.file_picker.pick_files(
+            dialog_title="파일 선택",
+            allow_multiple=True,
+            file_type=file_type,
+            allowed_extensions=allowed if allowed else None,
+        )
+
+    def _on_files_selected(self, e: ft.FilePickerResultEvent):
+        if not e.files:
+            return
+
+        new_paths = [f.path for f in e.files if f.path]
+        existing = set(self._selected_files)
+        added = [p for p in new_paths if p not in existing]
+
+        self._selected_files.extend(added)
+        self._rebuild_file_list()
+
+    def _rebuild_file_list(self):
+        """선택된 파일 목록 UI 갱신"""
+        self._file_list.controls.clear()
+
+        for filepath in self._selected_files:
+            name = Path(filepath).name
+
+            def make_remove(fp=filepath):
+                def remove(e):
+                    self._selected_files.remove(fp)
+                    self._rebuild_file_list()
+                return remove
+
+            row = ft.Row(
+                controls=[
+                    ft.Icon(ft.Icons.INSERT_DRIVE_FILE, size=14, color=Colors.TEXT_MUTED),
+                    ft.Text(
+                        name,
+                        size=Typography.SMALL,
+                        color=Colors.TEXT_SECONDARY,
+                        expand=True,
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                        tooltip=filepath,
+                    ),
+                    ft.IconButton(
+                        icon=ft.Icons.CLOSE,
+                        icon_size=14,
+                        icon_color=Colors.TEXT_MUTED,
+                        on_click=make_remove(),
+                        tooltip="제거",
+                        style=ft.ButtonStyle(
+                            padding=ft.padding.all(2),
+                        ),
+                    ),
+                ],
+                spacing=Spacing.XS,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            )
+            self._file_list.controls.append(row)
+
+        has_files = len(self._selected_files) > 0
+        self._file_list.visible = has_files
+        self._file_count_text.visible = has_files
+        self._file_count_text.value = f"{len(self._selected_files)}개 파일 선택됨" if has_files else ""
+
+        if self._file_list.page:
+            self._file_list.page.update()
 
     def get_stage(self) -> PipelineStage:
         """현재 선택된 시작 단계 반환"""
@@ -57,10 +198,13 @@ class StageSelector:
     def set_stage(self, stage: PipelineStage):
         """시작 단계 설정"""
         self._dropdown.value = str(stage.value)
+        show_picker = stage != PipelineStage.DOWNLOAD
+        self._pick_btn.visible = show_picker
 
     def set_enabled(self, enabled: bool):
         """활성/비활성 설정"""
         self._dropdown.disabled = not enabled
+        self._pick_btn.disabled = not enabled
 
     def get_files(self) -> list[str]:
         """선택된 입력 파일 목록 반환"""
@@ -69,3 +213,4 @@ class StageSelector:
     def set_files(self, files: list[str]):
         """입력 파일 목록 설정"""
         self._selected_files = list(files)
+        self._rebuild_file_list()

--- a/src/gui/components/stage_selector.py
+++ b/src/gui/components/stage_selector.py
@@ -1,0 +1,71 @@
+"""
+Flet 기반 파이프라인 시작 단계 선택기
+"""
+
+import flet as ft
+
+from src.gui.theme import Colors, Typography, Radius, Spacing
+from src.pipeline_stage import PipelineStage, STAGE_LABELS
+
+
+class StageSelector:
+    """파이프라인 시작 단계 선택 드롭다운"""
+
+    def __init__(self, on_change=None):
+        self._on_change = on_change
+        self._selected_files: list[str] = []
+
+        options = [
+            ft.dropdown.Option(
+                key=str(stage.value),
+                text=f"{stage.value}단계: {STAGE_LABELS[stage]}",
+            )
+            for stage in PipelineStage
+        ]
+
+        self._dropdown = ft.Dropdown(
+            options=options,
+            value=str(PipelineStage.DOWNLOAD.value),
+            label="시작 단계",
+            leading_icon=ft.Icons.SKIP_NEXT,
+            border_radius=Radius.SM,
+            border_color=Colors.BORDER,
+            focused_border_color=Colors.PRIMARY,
+            text_size=Typography.BODY,
+            label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
+            on_select=self._handle_change,
+            dense=True,
+        )
+
+        self.control = ft.Column(
+            controls=[self._dropdown],
+            spacing=Spacing.XS,
+            horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
+        )
+
+    def _handle_change(self, e):
+        if self._on_change:
+            self._on_change(self.get_stage())
+
+    def get_stage(self) -> PipelineStage:
+        """현재 선택된 시작 단계 반환"""
+        try:
+            return PipelineStage(int(self._dropdown.value))
+        except (ValueError, TypeError):
+            return PipelineStage.DOWNLOAD
+
+    def set_stage(self, stage: PipelineStage):
+        """시작 단계 설정"""
+        self._dropdown.value = str(stage.value)
+
+    def set_enabled(self, enabled: bool):
+        """활성/비활성 설정"""
+        self._dropdown.disabled = not enabled
+
+    def get_files(self) -> list[str]:
+        """선택된 입력 파일 목록 반환"""
+        return list(self._selected_files)
+
+    def set_files(self, files: list[str]):
+        """입력 파일 목록 설정"""
+        self._selected_files = list(files)

--- a/src/gui/core/artifact_detector.py
+++ b/src/gui/core/artifact_detector.py
@@ -1,0 +1,88 @@
+"""
+기존 파이프라인 산출물 감지 모듈
+
+다운로드 디렉토리를 스캔하여 이전 실행에서 생성된 산출물(MP4, WAV, TXT 등)을
+감지하고, 파이프라인을 이어서 실행할 수 있는 시작 단계를 추천한다.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from src.pipeline_stage import PipelineStage, ARTIFACT_EXTENSIONS
+
+
+class ArtifactDetector:
+    """다운로드 디렉토리의 기존 산출물을 감지"""
+
+    def __init__(self, directory: str):
+        self.directory = directory
+
+    def scan(self) -> Dict[PipelineStage, List[str]]:
+        """디렉토리를 재귀적으로 스캔하여 단계별 산출물 분류
+
+        Returns:
+            각 PipelineStage에 해당하는 파일 경로 목록
+        """
+        result: Dict[PipelineStage, List[str]] = {stage: [] for stage in PipelineStage}
+
+        if not os.path.isdir(self.directory):
+            return result
+
+        for root, _dirs, files in os.walk(self.directory):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                stage = self._classify_file(filename)
+                if stage is not None:
+                    result[stage].append(filepath)
+
+        return result
+
+    def recommend_start_stage(self) -> Tuple[PipelineStage, List[str]]:
+        """산출물 기반으로 다음 실행 단계를 추천
+
+        Returns:
+            (추천 시작 단계, 해당 단계의 입력 파일 목록)
+        """
+        artifacts = self.scan()
+
+        # 가장 진행된 단계부터 역순으로 확인
+        # .txt (요약되지 않은) 파일이 있으면 → SUMMARIZE 단계부터
+        if artifacts[PipelineStage.STT]:
+            return PipelineStage.SUMMARIZE, artifacts[PipelineStage.STT]
+
+        # .wav/.mp3 파일이 있으면 → STT 단계부터
+        if artifacts[PipelineStage.CONVERT_AUDIO]:
+            return PipelineStage.STT, artifacts[PipelineStage.CONVERT_AUDIO]
+
+        # .mp4/.ts 파일이 있으면 → CONVERT_AUDIO 단계부터
+        if artifacts[PipelineStage.DOWNLOAD]:
+            return PipelineStage.CONVERT_AUDIO, artifacts[PipelineStage.DOWNLOAD]
+
+        # 아무것도 없으면 처음부터
+        return PipelineStage.DOWNLOAD, []
+
+    @staticmethod
+    def _classify_file(filename: str) -> "PipelineStage | None":
+        """파일명을 기반으로 파이프라인 단계를 분류"""
+        lower = filename.lower()
+
+        # *_summarized.txt → SUMMARIZE 단계의 산출물 (이미 완료)
+        if lower.endswith("_summarized.txt"):
+            return PipelineStage.SUMMARIZE
+
+        # .txt (요약 아닌 것) → STT 단계의 산출물
+        if lower.endswith(".txt"):
+            return PipelineStage.STT
+
+        # .wav, .mp3 → CONVERT_AUDIO 단계의 산출물
+        for ext in ARTIFACT_EXTENSIONS[PipelineStage.CONVERT_AUDIO]:
+            if lower.endswith(ext):
+                return PipelineStage.CONVERT_AUDIO
+
+        # .mp4, .ts → DOWNLOAD 단계의 산출물
+        for ext in ARTIFACT_EXTENSIONS[PipelineStage.DOWNLOAD]:
+            if lower.endswith(ext):
+                return PipelineStage.DOWNLOAD
+
+        return None

--- a/src/gui/views/main_view.py
+++ b/src/gui/views/main_view.py
@@ -25,10 +25,12 @@ from src.gui.core.file_manager import (
 from src.gui.components.input_field import InputField
 from src.gui.components.log_area import LogArea
 from src.gui.components.model_selector import ModelSelector
+from src.gui.components.stage_selector import StageSelector
 from src.gui.views.progress_view import ProgressModal
 from src.gui.views.settings_view import open_settings_dialog
 from src.gui.views.course_list_view import CourseListView
 from src.gui.workers.processing_worker import ProcessingWorker
+from src.pipeline_stage import PipelineStage
 
 
 class MainView:
@@ -42,6 +44,7 @@ class MainView:
         self.input_fields: Dict[str, InputField] = {}
         self.log_area = LogArea()
         self.model_selector = ModelSelector()
+        self.stage_selector = StageSelector()
         self.worker: ProcessingWorker = None
         self.modal: ProgressModal = None
 
@@ -241,9 +244,10 @@ class MainView:
 
             form_controls.append(field.container)
 
-            # API 키 다음에 모델 선택기
+            # API 키 다음에 모델 선택기 + 시작 단계 선택기
             if name == 'api_key':
                 form_controls.append(self.model_selector.control)
+                form_controls.append(self.stage_selector.control)
 
         return card_container(
             content=ft.Column(
@@ -339,11 +343,28 @@ class MainView:
             self._handle_stop()
             return
 
+        start_stage = self.stage_selector.get_stage()
         inputs = {name: field.get_value() for name, field in self.input_fields.items()}
-        valid, error_message = InputValidator.validate_all_inputs(inputs)
-        if not valid:
-            self._show_snackbar(error_message, Colors.ERROR)
-            return
+
+        # 다운로드 단계부터 시작할 때만 전체 검증 필요
+        if start_stage == PipelineStage.DOWNLOAD:
+            valid, error_message = InputValidator.validate_all_inputs(inputs)
+            if not valid:
+                self._show_snackbar(error_message, Colors.ERROR)
+                return
+        else:
+            # 다운로드 이후 단계에서는 API 키만 검증 (요약에 필요)
+            if start_stage <= PipelineStage.SUMMARIZE:
+                valid, error = InputValidator.validate_api_key(inputs.get('api_key', ''))
+                if not valid:
+                    self._show_snackbar(error, Colors.ERROR)
+                    return
+
+            # 입력 파일이 있는지 확인
+            input_files = self.stage_selector.get_files()
+            if not input_files:
+                self._show_snackbar("시작 단계에 사용할 파일을 선택해주세요.", Colors.ERROR)
+                return
 
         all_loaded, missing = check_required_modules(self.modules)
         if not all_loaded:
@@ -354,6 +375,8 @@ class MainView:
 
     def _start_processing(self, inputs: Dict[str, str]):
         model_name = self.model_selector.get_model()
+        start_stage = self.stage_selector.get_stage()
+        input_files = self.stage_selector.get_files()
         save_user_inputs({**inputs, 'ai_model': model_name})
 
         self._is_processing = True
@@ -373,7 +396,7 @@ class MainView:
         save_video_dir = ensure_downloads_directory() if self._save_video_checkbox.value else None
 
         # 프로그레스 모달 생성
-        self.modal = ProgressModal(self.page, on_stop=self._on_modal_stop)
+        self.modal = ProgressModal(self.page, on_stop=self._on_modal_stop, start_stage=start_stage)
 
         def on_log(msg):
             self.log_area.append_message(msg)
@@ -434,6 +457,8 @@ class MainView:
             on_finished=on_finished,
             on_step_changed=on_step,
             on_progress=on_progress,
+            start_stage=start_stage,
+            input_files=input_files,
         )
 
         self.modal.show()
@@ -511,6 +536,7 @@ class MainView:
         for field in self.input_fields.values():
             field.set_enabled(enabled)
         self.model_selector.set_enabled(enabled)
+        self.stage_selector.set_enabled(enabled)
 
     def _check_module_status(self):
         if self.module_errors:

--- a/src/gui/views/main_view.py
+++ b/src/gui/views/main_view.py
@@ -55,6 +55,9 @@ class MainView:
         self._snackbar = ft.SnackBar(content=ft.Text(""), duration=3000)
         page.overlay.append(self._snackbar)
 
+        # StageSelector의 FilePicker를 overlay에 등록
+        page.overlay.append(self.stage_selector.file_picker)
+
         # 컨트롤 생성
         self._save_video_checkbox = ft.Checkbox(
             label="처리 완료 후 원본 동영상 보관 (미선택 시 자동 삭제)",

--- a/src/gui/views/progress_view.py
+++ b/src/gui/views/progress_view.py
@@ -14,9 +14,10 @@ _STEPS = [(stage.value, STAGE_LABELS[stage]) for stage in PipelineStage]
 class ProgressModal:
     """처리 진행 상황을 표시하는 모달"""
 
-    def __init__(self, page: ft.Page, on_stop=None):
+    def __init__(self, page: ft.Page, on_stop=None, start_stage: PipelineStage = PipelineStage.DOWNLOAD):
         self._page = page
         self._on_stop = on_stop
+        self._start_stage = start_stage
         self._is_finished = False
         self._log_visible = False
         self._log_messages: list[str] = []
@@ -24,12 +25,21 @@ class ProgressModal:
         # 단계 인디케이터
         self._step_rows: list[ft.Row] = []
         for num, name in _STEPS:
-            icon = ft.Text("○", size=14, color=Colors.TEXT_MUTED)
-            label = ft.Text(
-                f"{num}단계: {name}",
-                size=Typography.BODY,
-                color=Colors.TEXT_MUTED,
-            )
+            # start_stage 이전 단계는 건너뜀 표시 (회색 대시)
+            if num < start_stage:
+                icon = ft.Text("—", size=14, color=Colors.DISABLED)
+                label = ft.Text(
+                    f"{num}단계: {name}",
+                    size=Typography.BODY,
+                    color=Colors.DISABLED,
+                )
+            else:
+                icon = ft.Text("○", size=14, color=Colors.TEXT_MUTED)
+                label = ft.Text(
+                    f"{num}단계: {name}",
+                    size=Typography.BODY,
+                    color=Colors.TEXT_MUTED,
+                )
             row = ft.Row(controls=[icon, label], spacing=Spacing.SM)
             self._step_rows.append(row)
 
@@ -164,11 +174,15 @@ class ProgressModal:
             icon_ctrl = self._step_rows[i].controls[0]
             label_ctrl = self._step_rows[i].controls[1]
 
-            if i + 1 < step_num:
+            # 건너뛴 단계는 유지
+            if num < self._start_stage:
+                continue
+
+            if num < step_num:
                 icon_ctrl.value = "✓"
                 icon_ctrl.color = Colors.SUCCESS
                 label_ctrl.color = Colors.SUCCESS
-            elif i + 1 == step_num:
+            elif num == step_num:
                 icon_ctrl.value = "●"
                 icon_ctrl.color = Colors.PRIMARY
                 icon_ctrl.weight = Typography.BOLD
@@ -205,6 +219,9 @@ class ProgressModal:
     def mark_complete(self):
         self._is_finished = True
         for i, (num, name) in enumerate(_STEPS):
+            # 건너뛴 단계는 유지
+            if num < self._start_stage:
+                continue
             icon_ctrl = self._step_rows[i].controls[0]
             label_ctrl = self._step_rows[i].controls[1]
             icon_ctrl.value = "✓"

--- a/src/gui/views/progress_view.py
+++ b/src/gui/views/progress_view.py
@@ -5,13 +5,10 @@
 import flet as ft
 
 from src.gui.theme import Colors, Typography, Spacing, Radius, divider
+from src.pipeline_stage import PipelineStage, STAGE_LABELS
 
-# 처리 단계 정의
-_STEPS = [
-    (1, "영상 다운로드"),
-    (2, "음성 → 텍스트 변환"),
-    (3, "AI 요약 생성"),
-]
+# 처리 단계 정의 (PipelineStage 기반)
+_STEPS = [(stage.value, STAGE_LABELS[stage]) for stage in PipelineStage]
 
 
 class ProgressModal:

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -17,6 +17,7 @@ from src.gui.core.file_manager import (
     add_history_entry, get_app_data_dir,
 )
 from src.gui.core.module_loader import check_required_modules
+from src.pipeline_stage import PipelineStage, STAGE_LABELS
 
 
 def _setup_file_logger() -> logging.Logger:
@@ -50,6 +51,8 @@ class ProcessingWorker:
         on_finished: Optional[Callable[[bool, str], None]] = None,
         on_step_changed: Optional[Callable[[int, str], None]] = None,
         on_progress: Optional[Callable[[int, int], None]] = None,
+        start_stage: PipelineStage = PipelineStage.DOWNLOAD,
+        input_files: Optional[List[str]] = None,
     ):
         self.user_inputs = user_inputs
         self.modules = modules
@@ -59,6 +62,8 @@ class ProcessingWorker:
         self.chrome_path = get_chrome_path()
         self.debug_mode = get_debug_mode()
         self.stt_engine = get_stt_engine()
+        self.start_stage = start_stage
+        self.input_files = input_files or []
         self._cancel_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
 
@@ -109,7 +114,9 @@ class ProcessingWorker:
                 return
 
             self._check_cancelled()
-            self._create_configuration()
+            # 다운로드 단계부터 시작할 때만 설정 파일 생성
+            if self.start_stage <= PipelineStage.DOWNLOAD:
+                self._create_configuration()
             self._check_cancelled()
             self._execute_processing_pipeline()
 
@@ -141,55 +148,94 @@ class ProcessingWorker:
 
     def _execute_processing_pipeline(self):
         import time as _time
-        urls = extract_urls_from_input(self.user_inputs.get('urls', ''))
-        if not urls:
-            raise ValueError("처리할 URL이 없습니다.")
 
-        user_setting = self.modules['UserSetting'](self.user_inputs)
         pipeline_start = _time.time()
-
-        # 단계별 성능 측정
         step_timings = {}
 
-        # 1. 비디오 다운로드
-        self._check_cancelled()
-        self._on_step_changed(1, "영상 다운로드")
-        step_start = _time.time()
-        video_paths = self._download_videos(urls, user_setting)
-        step_timings["download_sec"] = round(_time.time() - step_start, 1)
+        video_paths: List[str] = []
+        wav_paths: List[str] = []
+        text_paths: List[str] = []
+        summary_paths: List[str] = []
+        video_sizes: Dict[str, float] = {}
+        urls: List[str] = []
 
-        if not video_paths:
-            raise ValueError(f"다운로드된 영상이 없습니다. ({len(urls)}개 URL 중 0개 성공)")
+        # ── 1. 영상 다운로드 ──
+        if self.start_stage <= PipelineStage.DOWNLOAD:
+            urls = extract_urls_from_input(self.user_inputs.get('urls', ''))
+            if not urls:
+                raise ValueError("처리할 URL이 없습니다.")
 
-        # 영상 파일 크기 기록 (삭제 전)
-        video_sizes = {}
-        for vp in video_paths:
-            try:
-                video_sizes[vp] = os.path.getsize(vp) / (1024 * 1024)
-            except OSError:
-                video_sizes[vp] = 0.0
+            user_setting = self.modules['UserSetting'](self.user_inputs)
 
-        # 2. 오디오 → 텍스트
-        self._check_cancelled()
-        self._on_step_changed(2, "음성 → 텍스트 변환")
-        step_start = _time.time()
-        text_paths = self._convert_audio_to_text(video_paths)
-        step_timings["stt_sec"] = round(_time.time() - step_start, 1)
+            self._check_cancelled()
+            self._on_step_changed(PipelineStage.DOWNLOAD, STAGE_LABELS[PipelineStage.DOWNLOAD])
+            step_start = _time.time()
+            video_paths = self._download_videos(urls, user_setting)
+            step_timings["download_sec"] = round(_time.time() - step_start, 1)
 
-        # 3. AI 요약
-        self._check_cancelled()
-        self._on_step_changed(3, "AI 요약 생성")
-        step_start = _time.time()
-        summary_paths = self._summarize_texts(text_paths)
-        step_timings["summary_sec"] = round(_time.time() - step_start, 1)
+            if not video_paths:
+                raise ValueError(f"다운로드된 영상이 없습니다. ({len(urls)}개 URL 중 0개 성공)")
 
-        # 히스토리 저장
+            # 영상 파일 크기 기록 (삭제 전)
+            for vp in video_paths:
+                try:
+                    video_sizes[vp] = os.path.getsize(vp) / (1024 * 1024)
+                except OSError:
+                    video_sizes[vp] = 0.0
+
+        # ── 2. MP4 → WAV 변환 ──
+        if self.start_stage <= PipelineStage.CONVERT_AUDIO:
+            self._check_cancelled()
+            self._on_step_changed(PipelineStage.CONVERT_AUDIO, STAGE_LABELS[PipelineStage.CONVERT_AUDIO])
+            step_start = _time.time()
+
+            # 시작 단계가 CONVERT_AUDIO이면 input_files를 사용
+            source_videos = self.input_files if self.start_stage == PipelineStage.CONVERT_AUDIO else video_paths
+            wav_paths = self._convert_videos_to_wav(source_videos)
+            step_timings["convert_sec"] = round(_time.time() - step_start, 1)
+
+        # ── 3. STT ──
+        if self.start_stage <= PipelineStage.STT:
+            self._check_cancelled()
+            self._on_step_changed(PipelineStage.STT, STAGE_LABELS[PipelineStage.STT])
+            step_start = _time.time()
+
+            # 시작 단계가 STT이면 input_files를 사용
+            source_wavs = self.input_files if self.start_stage == PipelineStage.STT else wav_paths
+            text_paths = self._transcribe_wav_to_text(source_wavs)
+            step_timings["stt_sec"] = round(_time.time() - step_start, 1)
+
+        # ── 4. AI 요약 ──
+        if self.start_stage <= PipelineStage.SUMMARIZE:
+            self._check_cancelled()
+            self._on_step_changed(PipelineStage.SUMMARIZE, STAGE_LABELS[PipelineStage.SUMMARIZE])
+            step_start = _time.time()
+
+            # 시작 단계가 SUMMARIZE이면 input_files를 사용
+            source_texts = self.input_files if self.start_stage == PipelineStage.SUMMARIZE else text_paths
+            summary_paths = self._summarize_texts(source_texts)
+            step_timings["summary_sec"] = round(_time.time() - step_start, 1)
+
+        # 히스토리 저장 (다운로드부터 시작한 경우에만)
         duration_sec = _time.time() - pipeline_start
         step_timings["total_sec"] = round(duration_sec, 1)
-        self._emit_log(f"⏱ 성능: 다운로드 {step_timings['download_sec']}초 | STT {step_timings['stt_sec']}초 | 요약 {step_timings['summary_sec']}초 | 전체 {step_timings['total_sec']}초")
-        self._save_processing_history(urls, video_paths, video_sizes, summary_paths, duration_sec, step_timings)
 
-        if not self.save_video_dir:
+        timing_parts = []
+        if "download_sec" in step_timings:
+            timing_parts.append(f"다운로드 {step_timings['download_sec']}초")
+        if "convert_sec" in step_timings:
+            timing_parts.append(f"변환 {step_timings['convert_sec']}초")
+        if "stt_sec" in step_timings:
+            timing_parts.append(f"STT {step_timings['stt_sec']}초")
+        if "summary_sec" in step_timings:
+            timing_parts.append(f"요약 {step_timings['summary_sec']}초")
+        timing_parts.append(f"전체 {step_timings['total_sec']}초")
+        self._emit_log(f"⏱ 성능: {' | '.join(timing_parts)}")
+
+        if urls and video_paths:
+            self._save_processing_history(urls, video_paths, video_sizes, summary_paths, duration_sec, step_timings)
+
+        if video_paths and not self.save_video_dir:
             self._delete_video_files(video_paths)
 
         self._display_results(video_paths, text_paths)
@@ -241,27 +287,52 @@ class ProcessingWorker:
             except Exception as e:
                 self._emit_log(f"⚠️ 영상 삭제 실패 ({Path(filepath).name}): {e}")
 
-    def _convert_audio_to_text(self, video_paths: List[str]) -> List[str]:
+    def _convert_videos_to_wav(self, video_paths: List[str]) -> List[str]:
+        """MP4/영상 파일들을 WAV로 변환"""
+        self._emit_log("📋 영상을 오디오(WAV)로 변환 중...")
+
+        audio_pipeline = self.modules['AudioToTextPipeline'](engine=self.stt_engine)
+        wav_paths = []
+
+        for i, video_path in enumerate(video_paths, 1):
+            self._check_cancelled()
+            try:
+                audio_pipeline.downloads_dir = str(Path(video_path).parent)
+                self._emit_log(f"({i}/{len(video_paths)}) WAV 변환 중: {Path(video_path).name}")
+
+                wav_path = audio_pipeline.convert_to_wav(video_path)
+                wav_paths.append(wav_path)
+                self._emit_log(f"✅ WAV 변환 완료: {wav_path}")
+
+            except CancelledException:
+                raise
+            except Exception as e:
+                self._emit_log(f"❌ WAV 변환 실패 ({Path(video_path).name}): {e}")
+
+        return wav_paths
+
+    def _transcribe_wav_to_text(self, wav_paths: List[str]) -> List[str]:
+        """WAV 파일들을 텍스트로 변환"""
         self._emit_log(Messages.AUDIO_CONVERTING)
 
         audio_pipeline = self.modules['AudioToTextPipeline'](engine=self.stt_engine)
         self._emit_log(f"STT 엔진: {self.stt_engine}")
         text_paths = []
 
-        for i, video_path in enumerate(video_paths, 1):
+        for i, wav_path in enumerate(wav_paths, 1):
             self._check_cancelled()
             try:
-                audio_pipeline.downloads_dir = str(Path(video_path).parent)
-                self._emit_log(f"({i}/{len(video_paths)}) 텍스트 변환 중: {Path(video_path).name}")
+                audio_pipeline.downloads_dir = str(Path(wav_path).parent)
+                self._emit_log(f"({i}/{len(wav_paths)}) 텍스트 변환 중: {Path(wav_path).name}")
 
-                text_path = audio_pipeline.process(video_path)
+                text_path = audio_pipeline.transcribe(wav_path, remove_wav=True)
                 text_paths.append(text_path)
                 self._emit_log(f"{Messages.CONVERSION_COMPLETE}: {text_path}")
 
             except CancelledException:
                 raise
             except Exception as e:
-                self._emit_log(f"{Messages.CONVERSION_FAILED} ({Path(video_path).name}): {e}")
+                self._emit_log(f"{Messages.CONVERSION_FAILED} ({Path(wav_path).name}): {e}")
 
         if text_paths:
             self._emit_log("변환된 텍스트 파일들:")
@@ -269,6 +340,11 @@ class ProcessingWorker:
                 self._emit_log(f"   ({i}) {text_path}")
 
         return text_paths
+
+    # 하위 호환: 기존 _convert_audio_to_text 을 유지 (직접 호출하는 곳은 없지만 안전)
+    def _convert_audio_to_text(self, video_paths: List[str]) -> List[str]:
+        wav_paths = self._convert_videos_to_wav(video_paths)
+        return self._transcribe_wav_to_text(wav_paths)
 
     def _summarize_texts(self, text_paths: List[str]) -> List[str]:
         self._emit_log(Messages.TEXT_SUMMARIZING)

--- a/src/pipeline_stage.py
+++ b/src/pipeline_stage.py
@@ -1,0 +1,23 @@
+from enum import IntEnum
+
+
+class PipelineStage(IntEnum):
+    DOWNLOAD = 1        # 영상 다운로드
+    CONVERT_AUDIO = 2   # MP4 → WAV 변환
+    STT = 3             # STT 텍스트 변환
+    SUMMARIZE = 4       # AI 요약
+
+
+STAGE_LABELS = {
+    PipelineStage.DOWNLOAD: "영상 다운로드",
+    PipelineStage.CONVERT_AUDIO: "MP3/WAV 변환",
+    PipelineStage.STT: "음성 → 텍스트 변환",
+    PipelineStage.SUMMARIZE: "AI 요약 생성",
+}
+
+ARTIFACT_EXTENSIONS = {
+    PipelineStage.DOWNLOAD: [".mp4", ".ts"],
+    PipelineStage.CONVERT_AUDIO: [".wav", ".mp3"],
+    PipelineStage.STT: [".txt"],  # excluding *_summarized.txt
+    PipelineStage.SUMMARIZE: ["_summarized.txt"],
+}


### PR DESCRIPTION
## Summary
- 파이프라인을 4단계(다운로드 → WAV변환 → STT → AI요약)로 분리하여 각 단계를 독립 실행 가능하도록 리팩토링
- GUI에 시작 단계 선택 드롭다운 + 파일 선택기 추가
- 출력 폴더 스캔으로 기존 산출물 자동 감지 및 시작 단계 추천

## Changes
- `src/pipeline_stage.py` (신규) - PipelineStage enum, 단계별 라벨/확장자 상수
- `src/gui/core/artifact_detector.py` (신규) - 산출물 감지 및 시작 단계 추천
- `src/gui/components/stage_selector.py` (신규) - 시작 단계 선택 + 파일 선택기 + 자동 감지 UI
- `src/audio_pipeline/pipeline.py` - process()를 convert_to_wav() + transcribe()로 분리
- `src/gui/workers/processing_worker.py` - 4단계 조건부 실행, start_stage/input_files 지원
- `src/gui/views/progress_view.py` - 4단계 표시, 건너뛴 단계 회색 표시
- `src/gui/views/main_view.py` - StageSelector 통합, 조건부 유효성 검사

## Test plan
- [ ] 기본 동작(1단계부터 시작)이 기존과 동일하게 동작하는지 확인
- [ ] 각 단계별 시작이 정상 동작하는지 확인 (MP4/WAV/TXT 파일 직접 지정)
- [ ] 파일 선택기가 단계에 맞는 확장자만 필터링하는지 확인
- [ ] 자동 감지 버튼이 출력 폴더의 산출물을 정확히 감지하는지 확인
- [ ] 2단계 이상 시작 시 URL/로그인 정보 없이도 실행 가능한지 확인
- [ ] 진행 Modal에서 건너뛴 단계가 회색으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)