### PR TITLE
feat: 멀티 AI 엔진 지원 (Gemini/OpenAI/Claude/Grok + 클립보드 모드)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "requests>=2.32.3",
     "av>=13.0.0",
+    "anthropic>=0.84.0",
 ]
 
 [project.scripts]

--- a/src/gui/components/model_selector.py
+++ b/src/gui/components/model_selector.py
@@ -1,28 +1,66 @@
 """
-Flet 기반 AI 모델 선택기
+Flet 기반 AI 엔진 + 모델 선택기
 """
 
 import flet as ft
 
-from src.gui.theme import Colors, Typography, Radius
+from src.gui.theme import Colors, Typography, Radius, Spacing
+from src.summarize_pipeline.providers import ENGINE_REGISTRY, ClipboardProvider
 
-# 기본 모델 목록
-_DEFAULT_MODELS = [
-    ("gemini-2.5-flash", "Gemini 2.5 Flash (추천)"),
-    ("gemini-2.5-pro", "Gemini 2.5 Pro"),
-    ("gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite"),
-    ("gemini-2.0-flash", "Gemini 2.0 Flash"),
-    ("gemini-2.0-flash-lite", "Gemini 2.0 Flash Lite"),
+# 엔진 드롭다운에 표시할 목록 (순서 유지)
+_ENGINE_OPTIONS = [
+    ("gemini", "Google Gemini"),
+    ("openai", "OpenAI"),
+    ("claude", "Anthropic Claude"),
+    ("grok", "xAI Grok"),
+    ("clipboard", "API 키 없이 사용"),
 ]
 
 _CUSTOM_KEY = "__custom__"
 
 
-class ModelSelector:
-    """AI 모델 선택 드롭다운"""
+class EngineModelSelector:
+    """AI 엔진 + 모델 선택 드롭다운"""
 
-    def __init__(self, on_change=None):
-        self._on_change = on_change
+    def __init__(self, on_engine_change=None, on_model_change=None):
+        self._on_engine_change = on_engine_change
+        self._on_model_change = on_model_change
+        self._current_engine = "gemini"
+
+        # 엔진 드롭다운
+        engine_options = [
+            ft.dropdown.Option(key=k, text=t) for k, t in _ENGINE_OPTIONS
+        ]
+        self._engine_dropdown = ft.Dropdown(
+            options=engine_options,
+            value="gemini",
+            label="AI 엔진",
+            leading_icon=ft.Icons.AUTO_AWESOME,
+            border_radius=Radius.SM,
+            border_color=Colors.BORDER,
+            focused_border_color=Colors.PRIMARY,
+            text_size=Typography.BODY,
+            label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
+            on_select=self._handle_engine_change,
+            dense=True,
+        )
+
+        # 모델 드롭다운
+        self._model_dropdown = ft.Dropdown(
+            options=[],
+            value=None,
+            label="AI 모델",
+            leading_icon=ft.Icons.SMART_TOY,
+            border_radius=Radius.SM,
+            border_color=Colors.BORDER,
+            focused_border_color=Colors.PRIMARY,
+            text_size=Typography.BODY,
+            label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
+            on_select=self._handle_model_change,
+            dense=True,
+        )
+
+        # 커스텀 모델 입력
         self._custom_input = ft.TextField(
             hint_text="모델명 직접 입력",
             border_radius=Radius.SM,
@@ -33,52 +71,100 @@ class ModelSelector:
             dense=True,
         )
 
-        options = [ft.dropdown.Option(key=k, text=t) for k, t in _DEFAULT_MODELS]
-        options.append(ft.dropdown.Option(key=_CUSTOM_KEY, text="직접 입력..."))
-
-        self._dropdown = ft.Dropdown(
-            options=options,
-            value="gemini-2.5-flash",
-            label="AI 모델",
-            leading_icon=ft.Icons.SMART_TOY,
-            border_radius=Radius.SM,
-            border_color=Colors.BORDER,
-            focused_border_color=Colors.PRIMARY,
-            text_size=Typography.BODY,
-            label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
-            on_select=self._handle_change,
-            dense=True,
-        )
+        # 초기 모델 목록 채우기
+        self._refresh_model_list()
 
         self.control = ft.Column(
-            controls=[self._dropdown, self._custom_input],
-            spacing=4,
+            controls=[self._engine_dropdown, self._model_dropdown, self._custom_input],
+            spacing=Spacing.XS,
             horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
         )
 
-    def _handle_change(self, e):
-        is_custom = self._dropdown.value == _CUSTOM_KEY
+    def _get_models_for_engine(self, engine: str) -> list[tuple[str, str]]:
+        """엔진에 해당하는 모델 목록 반환"""
+        if engine == "clipboard":
+            return ClipboardProvider.available_models()
+        cls = ENGINE_REGISTRY.get(engine)
+        if cls:
+            return cls.available_models()
+        return []
+
+    def _refresh_model_list(self):
+        """현재 선택된 엔진에 맞게 모델 드롭다운 갱신"""
+        models = self._get_models_for_engine(self._current_engine)
+        options = [ft.dropdown.Option(key=k, text=t) for k, t in models]
+        options.append(ft.dropdown.Option(key=_CUSTOM_KEY, text="직접 입력..."))
+
+        self._model_dropdown.options = options
+        if models:
+            self._model_dropdown.value = models[0][0]
+        else:
+            self._model_dropdown.value = None
+
+        self._custom_input.visible = False
+
+    def _handle_engine_change(self, e):
+        self._current_engine = self._engine_dropdown.value or "gemini"
+        self._refresh_model_list()
+
+        # UI 업데이트
+        if self._model_dropdown.page:
+            self._model_dropdown.update()
+        if self._custom_input.page:
+            self._custom_input.update()
+
+        if self._on_engine_change:
+            self._on_engine_change(self._current_engine)
+
+    def _handle_model_change(self, e):
+        is_custom = self._model_dropdown.value == _CUSTOM_KEY
         self._custom_input.visible = is_custom
         if self._custom_input.page:
             self._custom_input.update()
-        if self._on_change:
-            self._on_change(self.get_model())
+        if self._on_model_change:
+            self._on_model_change(self.get_model())
+
+    def get_engine(self) -> str:
+        """현재 선택된 엔진 반환"""
+        return self._current_engine
 
     def get_model(self) -> str:
-        if self._dropdown.value == _CUSTOM_KEY:
-            return self._custom_input.value or "gemini-2.5-flash"
-        return self._dropdown.value or "gemini-2.5-flash"
+        """현재 선택된 모델명 반환"""
+        if self._model_dropdown.value == _CUSTOM_KEY:
+            custom = self._custom_input.value or ""
+            if custom.strip():
+                return custom.strip()
+            # 커스텀 입력이 비어있으면 기본 모델
+            models = self._get_models_for_engine(self._current_engine)
+            return models[0][0] if models else ""
+        return self._model_dropdown.value or ""
+
+    def set_engine(self, engine: str):
+        """엔진 설정"""
+        known_engines = [k for k, _ in _ENGINE_OPTIONS]
+        if engine in known_engines:
+            self._current_engine = engine
+            self._engine_dropdown.value = engine
+            self._refresh_model_list()
 
     def set_model(self, model_name: str):
-        known_keys = [k for k, _ in _DEFAULT_MODELS]
+        """모델 설정"""
+        models = self._get_models_for_engine(self._current_engine)
+        known_keys = [k for k, _ in models]
         if model_name in known_keys:
-            self._dropdown.value = model_name
+            self._model_dropdown.value = model_name
             self._custom_input.visible = False
         else:
-            self._dropdown.value = _CUSTOM_KEY
+            self._model_dropdown.value = _CUSTOM_KEY
             self._custom_input.value = model_name
             self._custom_input.visible = True
 
     def set_enabled(self, enabled: bool):
-        self._dropdown.disabled = not enabled
+        """활성/비활성 전환"""
+        self._engine_dropdown.disabled = not enabled
+        self._model_dropdown.disabled = not enabled
         self._custom_input.disabled = not enabled
+
+
+# 하위 호환을 위한 별칭
+ModelSelector = EngineModelSelector

--- a/src/gui/config/settings.py
+++ b/src/gui/config/settings.py
@@ -39,8 +39,8 @@ INPUT_FIELD_CONFIGS = {
         icon="lock",
     ),
     'api_key': InputFieldConfig(
-        label="Gemini API 키:",
-        placeholder="sk-... (Gemini API 키를 입력하세요)",
+        label="AI API 키:",
+        placeholder="AI 엔진의 API 키를 입력하세요",
         icon="key",
     ),
     'urls': InputFieldConfig(

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -136,15 +136,54 @@ _PERSISTABLE_FIELDS = ['student_id', 'api_key', 'ai_model', 'ai_engine']
 
 
 def save_user_inputs(inputs: Dict[str, str]) -> None:
-    """사용자 입력값을 설정 파일에 저장 (비밀번호 제외)"""
+    """사용자 입력값을 설정 파일에 저장 (비밀번호 제외)
+
+    API 키는 엔진별로 분리하여 저장합니다.
+    예: api_keys = {"gemini": "...", "openai": "...", ...}
+    """
     settings = load_settings()
-    settings['user_inputs'] = {k: inputs[k] for k in _PERSISTABLE_FIELDS if k in inputs}
+    saved = {k: inputs[k] for k in _PERSISTABLE_FIELDS if k in inputs}
+
+    # 엔진별 API 키 저장
+    engine = inputs.get('ai_engine', 'gemini')
+    api_key = inputs.get('api_key', '')
+    api_keys = settings.get('api_keys', {})
+    if api_key:
+        api_keys[engine] = api_key
+    saved['api_keys'] = api_keys
+
+    settings['user_inputs'] = saved
+    settings['api_keys'] = api_keys
     save_settings(settings)
 
 
 def load_user_inputs() -> Dict[str, str]:
-    """저장된 사용자 입력값 로드"""
-    return load_settings().get('user_inputs', {})
+    """저장된 사용자 입력값 로드
+
+    마이그레이션: 기존 api_key만 저장된 경우 gemini 키로 처리합니다.
+    """
+    settings = load_settings()
+    saved = settings.get('user_inputs', {})
+
+    # 마이그레이션: 기존 api_key가 있고 api_keys가 없으면 gemini 키로 간주
+    api_keys = settings.get('api_keys', saved.get('api_keys', {}))
+    if not api_keys and saved.get('api_key'):
+        api_keys = {"gemini": saved['api_key']}
+
+    # 현재 엔진에 맞는 API 키 복원
+    engine = saved.get('ai_engine', 'gemini')
+    if api_keys.get(engine):
+        saved['api_key'] = api_keys[engine]
+
+    saved['api_keys'] = api_keys
+    return saved
+
+
+def get_api_key_for_engine(engine: str) -> str:
+    """특정 엔진의 저장된 API 키 반환"""
+    settings = load_settings()
+    api_keys = settings.get('api_keys', {})
+    return api_keys.get(engine, '')
 
 
 def get_downloads_dir() -> str:

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -132,7 +132,7 @@ def extract_urls_from_input(url_input: str) -> List[str]:
     return urls
 
 
-_PERSISTABLE_FIELDS = ['student_id', 'api_key', 'ai_model']
+_PERSISTABLE_FIELDS = ['student_id', 'api_key', 'ai_model', 'ai_engine']
 
 
 def save_user_inputs(inputs: Dict[str, str]) -> None:

--- a/src/gui/core/validators.py
+++ b/src/gui/core/validators.py
@@ -99,8 +99,13 @@ class InputValidator:
             return False
 
     @staticmethod
-    def validate_all_inputs(inputs: Dict[str, str]) -> Tuple[bool, str]:
-        """모든 입력값 종합 검증"""
+    def validate_all_inputs(inputs: Dict[str, str], skip_api_key: bool = False) -> Tuple[bool, str]:
+        """모든 입력값 종합 검증
+
+        Args:
+            inputs: 입력값 딕셔너리
+            skip_api_key: True이면 API 키 검증을 건너뜀 (클립보드 모드 등)
+        """
         # 학번 검증
         valid, error = InputValidator.validate_student_id(inputs.get('student_id', ''))
         if not valid:
@@ -111,10 +116,11 @@ class InputValidator:
         if not valid:
             return False, error
 
-        # API 키 검증
-        valid, error = InputValidator.validate_api_key(inputs.get('api_key', ''))
-        if not valid:
-            return False, error
+        # API 키 검증 (클립보드 모드에서는 건너뜀)
+        if not skip_api_key:
+            valid, error = InputValidator.validate_api_key(inputs.get('api_key', ''))
+            if not valid:
+                return False, error
 
         # URL 검증
         valid, error, urls = InputValidator.validate_urls(inputs.get('urls', ''))

--- a/src/gui/views/main_view.py
+++ b/src/gui/views/main_view.py
@@ -24,7 +24,7 @@ from src.gui.core.file_manager import (
 )
 from src.gui.components.input_field import InputField
 from src.gui.components.log_area import LogArea
-from src.gui.components.model_selector import ModelSelector
+from src.gui.components.model_selector import EngineModelSelector
 from src.gui.views.progress_view import ProgressModal
 from src.gui.views.settings_view import open_settings_dialog
 from src.gui.views.course_list_view import CourseListView
@@ -41,7 +41,9 @@ class MainView:
 
         self.input_fields: Dict[str, InputField] = {}
         self.log_area = LogArea()
-        self.model_selector = ModelSelector()
+        self.model_selector = EngineModelSelector(
+            on_engine_change=self._on_engine_change,
+        )
         self.worker: ProcessingWorker = None
         self.modal: ProgressModal = None
 
@@ -334,13 +336,38 @@ class MainView:
         self.log_area.append_message(msg)
         self.page.update()
 
+    def _on_engine_change(self, engine: str):
+        """엔진 변경 시 API 키 필드 라벨/표시 업데이트"""
+        _ENGINE_LABELS = {
+            "gemini": "Gemini API 키:",
+            "openai": "OpenAI API 키:",
+            "claude": "Anthropic API 키:",
+            "grok": "xAI API 키:",
+            "clipboard": "API 키 (불필요):",
+        }
+        api_field = self.input_fields.get('api_key')
+        if api_field:
+            new_label = _ENGINE_LABELS.get(engine, "AI API 키:")
+            api_field.control.label = new_label
+            is_clipboard = engine == "clipboard"
+            api_field.set_enabled(not is_clipboard)
+            if api_field.control.page:
+                api_field.control.update()
+        try:
+            self.page.update()
+        except Exception:
+            pass
+
     def _handle_start(self, e=None):
         if self._is_processing:
             self._handle_stop()
             return
 
+        current_engine = self.model_selector.get_engine()
         inputs = {name: field.get_value() for name, field in self.input_fields.items()}
-        valid, error_message = InputValidator.validate_all_inputs(inputs)
+        valid, error_message = InputValidator.validate_all_inputs(
+            inputs, skip_api_key=(current_engine == "clipboard"),
+        )
         if not valid:
             self._show_snackbar(error_message, Colors.ERROR)
             return
@@ -353,8 +380,9 @@ class MainView:
         self._start_processing(inputs)
 
     def _start_processing(self, inputs: Dict[str, str]):
+        engine = self.model_selector.get_engine()
         model_name = self.model_selector.get_model()
-        save_user_inputs({**inputs, 'ai_model': model_name})
+        save_user_inputs({**inputs, 'ai_model': model_name, 'ai_engine': engine})
 
         self._is_processing = True
         self._start_btn.content.value = "중지"
@@ -430,6 +458,7 @@ class MainView:
             inputs, self.modules,
             save_video_dir=save_video_dir,
             model_name=model_name,
+            engine=engine,
             on_log=on_log,
             on_finished=on_finished,
             on_step_changed=on_step,
@@ -525,6 +554,8 @@ class MainView:
         for field_name, value in saved.items():
             if field_name in self.input_fields and value:
                 self.input_fields[field_name].set_value(value)
+        if 'ai_engine' in saved:
+            self.model_selector.set_engine(saved['ai_engine'])
         if 'ai_model' in saved:
             self.model_selector.set_model(saved['ai_model'])
         self.page.update()

--- a/src/gui/views/main_view.py
+++ b/src/gui/views/main_view.py
@@ -20,7 +20,7 @@ from src.gui.core.validators import InputValidator
 from src.gui.core.module_loader import check_required_modules
 from src.gui.core.file_manager import (
     ensure_downloads_directory, set_downloads_directory,
-    save_user_inputs, load_user_inputs,
+    save_user_inputs, load_user_inputs, get_api_key_for_engine,
 )
 from src.gui.components.input_field import InputField
 from src.gui.components.log_area import LogArea
@@ -337,7 +337,7 @@ class MainView:
         self.page.update()
 
     def _on_engine_change(self, engine: str):
-        """엔진 변경 시 API 키 필드 라벨/표시 업데이트"""
+        """엔진 변경 시 API 키 필드 라벨/표시 업데이트 및 저장된 키 복원"""
         _ENGINE_LABELS = {
             "gemini": "Gemini API 키:",
             "openai": "OpenAI API 키:",
@@ -351,6 +351,13 @@ class MainView:
             api_field.control.label = new_label
             is_clipboard = engine == "clipboard"
             api_field.set_enabled(not is_clipboard)
+
+            # 엔진별 저장된 API 키 복원
+            if not is_clipboard:
+                saved_key = get_api_key_for_engine(engine)
+                if saved_key:
+                    api_field.set_value(saved_key)
+
             if api_field.control.page:
                 api_field.control.update()
         try:

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -276,6 +276,10 @@ class ProcessingWorker:
         self._emit_log(Messages.TEXT_SUMMARIZING)
         self._emit_log(f"AI 엔진: {self.engine} / 모델: {self.model_name}")
 
+        is_clipboard = self.engine == "clipboard"
+        if is_clipboard:
+            self._emit_log("클립보드 모드: 프롬프트가 클립보드에 복사되고 외부 챗봇이 열립니다.")
+
         api_key = self.user_inputs.get('api_key', '')
         summarize_pipeline = self.modules['SummarizePipeline'](
             self.model_name,
@@ -291,6 +295,10 @@ class ProcessingWorker:
                 summarize_pipeline.downloads_dir = str(Path(text_path).parent)
                 self._emit_log(f"({i}/{len(text_paths)}) 요약 생성 중: {Path(text_path).name}")
 
+                # 클립보드 모드: 챗봇용 텍스트 파일도 생성
+                if is_clipboard:
+                    self._write_chatbot_text(text_path)
+
                 summary_path = summarize_pipeline.process(text_path)
                 summary_paths.append(summary_path)
                 self._emit_log(f"{Messages.SUMMARY_COMPLETE}: {summary_path}")
@@ -301,6 +309,19 @@ class ProcessingWorker:
                 self._emit_log(f"{Messages.SUMMARY_FAILED} ({Path(text_path).name}): {e}")
 
         return summary_paths
+
+    def _write_chatbot_text(self, text_path: str):
+        """클립보드 모드에서 챗봇에 붙여넣기용 텍스트 파일 생성"""
+        try:
+            with open(text_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            chatbot_path = text_path.replace('.txt', '_for_chatbot.txt')
+            chatbot_content = f"{self.summary_prompt}\n\n다음 텍스트를 요약해줘:\n\n{content}"
+            with open(chatbot_path, 'w', encoding='utf-8') as f:
+                f.write(chatbot_content)
+            self._emit_log(f"챗봇용 텍스트 저장: {Path(chatbot_path).name}")
+        except Exception as e:
+            self._emit_log(f"⚠️ 챗봇용 텍스트 생성 실패: {e}")
 
 
     def _save_processing_history(

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -46,6 +46,7 @@ class ProcessingWorker:
         modules: Dict,
         save_video_dir: str = None,
         model_name: str = "gemini-2.5-flash",
+        engine: str = "gemini",
         on_log: Optional[Callable[[str], None]] = None,
         on_finished: Optional[Callable[[bool, str], None]] = None,
         on_step_changed: Optional[Callable[[int, str], None]] = None,
@@ -55,6 +56,7 @@ class ProcessingWorker:
         self.modules = modules
         self.save_video_dir = save_video_dir
         self.model_name = model_name
+        self.engine = engine
         self.summary_prompt = get_summary_prompt()
         self.chrome_path = get_chrome_path()
         self.debug_mode = get_debug_mode()
@@ -272,8 +274,15 @@ class ProcessingWorker:
 
     def _summarize_texts(self, text_paths: List[str]) -> List[str]:
         self._emit_log(Messages.TEXT_SUMMARIZING)
+        self._emit_log(f"AI 엔진: {self.engine} / 모델: {self.model_name}")
 
-        summarize_pipeline = self.modules['SummarizePipeline'](self.model_name, prompt=self.summary_prompt)
+        api_key = self.user_inputs.get('api_key', '')
+        summarize_pipeline = self.modules['SummarizePipeline'](
+            self.model_name,
+            prompt=self.summary_prompt,
+            engine=self.engine,
+            api_key=api_key,
+        )
         summary_paths = []
 
         for i, text_path in enumerate(text_paths, 1):

--- a/src/summarize_pipeline/pipeline.py
+++ b/src/summarize_pipeline/pipeline.py
@@ -2,7 +2,7 @@ import os
 import time
 from pathlib import Path
 
-from src.summarize_pipeline.summarizer import summarize_text
+from src.summarize_pipeline.providers import create_provider
 
 try:
     from src.gui.core.file_manager import DEFAULT_PROMPT as _DEFAULT_PROMPT
@@ -11,10 +11,18 @@ except ImportError:
 
 
 class SummarizePipeline:
-    def __init__(self, model_name: str = "gemini-2.5-flash", prompt: str = None):
+    def __init__(
+        self,
+        model_name: str = "gemini-2.5-flash",
+        prompt: str = None,
+        engine: str = "gemini",
+        api_key: str = None,
+    ):
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
         self.model_name = model_name
         self.prompt = prompt or _DEFAULT_PROMPT
+        self.engine = engine
+        self.api_key = api_key
 
     def process(self, text_path: str) -> str:
         """텍스트 요약"""
@@ -24,8 +32,14 @@ class SummarizePipeline:
 
         print(f"[INFO] 요약 시작: {text_path}")
         start_time = time.time()
-        summary = summarize_text(text_path, self.prompt,
-                                 model_name=self.model_name)
+
+        # 텍스트 파일 읽기
+        with open(text_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Provider를 통해 요약 생성
+        provider = create_provider(self.engine, api_key=self.api_key, model_name=self.model_name)
+        summary = provider.summarize(content, self.prompt)
 
         end_time = time.time()
         print(f"[INFO] 요약 완료: {summary}")

--- a/src/summarize_pipeline/providers/__init__.py
+++ b/src/summarize_pipeline/providers/__init__.py
@@ -6,8 +6,57 @@ AI Provider 패키지
 
 from .base import AIProvider
 from .gemini_provider import GeminiProvider
+from .openai_provider import OpenAIProvider
+from .claude_provider import ClaudeProvider
+from .grok_provider import GrokProvider
+from .clipboard_provider import ClipboardProvider
+
+# 엔진 이름 → Provider 클래스 매핑
+ENGINE_REGISTRY: dict[str, type[AIProvider]] = {
+    "gemini": GeminiProvider,
+    "openai": OpenAIProvider,
+    "claude": ClaudeProvider,
+    "grok": GrokProvider,
+}
+
+# 엔진 이름 → API 키 설정 필드명 매핑
+ENGINE_API_KEY_MAP: dict[str, str] = {
+    "gemini": "GOOGLE_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "claude": "ANTHROPIC_API_KEY",
+    "grok": "XAI_API_KEY",
+}
+
+
+def create_provider(engine: str, api_key: str = None, model_name: str = None) -> AIProvider:
+    """엔진 이름으로 Provider 인스턴스를 생성하는 팩토리 함수
+
+    Args:
+        engine: 엔진 이름 ("gemini", "openai", "claude", "grok", "clipboard")
+        api_key: API 키 (clipboard 모드에서는 불필요)
+        model_name: 모델명 (None이면 기본 모델 사용)
+
+    Returns:
+        AIProvider 인스턴스
+    """
+    if engine == "clipboard":
+        return ClipboardProvider(target=model_name or "chatgpt")
+
+    cls = ENGINE_REGISTRY.get(engine)
+    if not cls:
+        raise ValueError(f"지원하지 않는 엔진: {engine}")
+
+    return cls(api_key=api_key, model_name=model_name or cls.default_model())
+
 
 __all__ = [
     "AIProvider",
     "GeminiProvider",
+    "OpenAIProvider",
+    "ClaudeProvider",
+    "GrokProvider",
+    "ClipboardProvider",
+    "ENGINE_REGISTRY",
+    "ENGINE_API_KEY_MAP",
+    "create_provider",
 ]

--- a/src/summarize_pipeline/providers/__init__.py
+++ b/src/summarize_pipeline/providers/__init__.py
@@ -1,0 +1,13 @@
+"""
+AI Provider 패키지
+
+다양한 AI 엔진을 통합하는 Provider 인터페이스를 제공합니다.
+"""
+
+from .base import AIProvider
+from .gemini_provider import GeminiProvider
+
+__all__ = [
+    "AIProvider",
+    "GeminiProvider",
+]

--- a/src/summarize_pipeline/providers/base.py
+++ b/src/summarize_pipeline/providers/base.py
@@ -1,0 +1,26 @@
+"""
+AI Provider 추상 인터페이스
+"""
+
+from abc import ABC, abstractmethod
+
+
+class AIProvider(ABC):
+    """AI 요약 엔진의 공통 인터페이스"""
+
+    @abstractmethod
+    def summarize(self, text: str, prompt: str) -> str:
+        """텍스트를 요약하여 반환"""
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def default_model() -> str:
+        """기본 모델명 반환"""
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def available_models() -> list[tuple[str, str]]:
+        """사용 가능한 모델 목록 반환: [(model_id, display_name), ...]"""
+        pass

--- a/src/summarize_pipeline/providers/claude_provider.py
+++ b/src/summarize_pipeline/providers/claude_provider.py
@@ -1,0 +1,34 @@
+"""
+Anthropic Claude AI Provider
+"""
+
+from .base import AIProvider
+
+
+class ClaudeProvider(AIProvider):
+    """Anthropic Claude API를 사용한 요약 엔진"""
+
+    def __init__(self, api_key: str, model_name: str = None):
+        from anthropic import Anthropic
+        self.client = Anthropic(api_key=api_key)
+        self.model_name = model_name or self.default_model()
+
+    def summarize(self, text: str, prompt: str) -> str:
+        full_prompt = f"{prompt}\n\n다음은 전체 텍스트입니다:\n{text}"
+        message = self.client.messages.create(
+            model=self.model_name,
+            max_tokens=8192,
+            messages=[{"role": "user", "content": full_prompt}],
+        )
+        return message.content[0].text
+
+    @staticmethod
+    def default_model() -> str:
+        return "claude-sonnet-4-20250514"
+
+    @staticmethod
+    def available_models() -> list[tuple[str, str]]:
+        return [
+            ("claude-sonnet-4-20250514", "Claude Sonnet 4 (추천)"),
+            ("claude-haiku-4-5-20241022", "Claude Haiku 4.5"),
+        ]

--- a/src/summarize_pipeline/providers/clipboard_provider.py
+++ b/src/summarize_pipeline/providers/clipboard_provider.py
@@ -1,0 +1,47 @@
+"""
+클립보드 기반 Provider (API 키 없이 사용)
+
+기존 ChatGPTSummarizer의 클립보드 복사 + 브라우저 열기 패턴을 일반화합니다.
+ChatGPT, Claude 웹, Grok 웹 등 다양한 챗봇으로 확장 가능합니다.
+"""
+
+import pyperclip
+import webbrowser
+
+from .base import AIProvider
+
+
+CHATBOT_URLS = {
+    "chatgpt": "https://chat.openai.com/chat",
+    "claude-web": "https://claude.ai/new",
+    "grok-web": "https://x.com/i/grok",
+}
+
+
+class ClipboardProvider(AIProvider):
+    """클립보드 복사 + 외부 챗봇 브라우저 열기 방식의 Provider"""
+
+    def __init__(self, target: str = "chatgpt", **kwargs):
+        self.target = target
+        self.chat_url = CHATBOT_URLS.get(target, CHATBOT_URLS["chatgpt"])
+
+    def summarize(self, text: str, prompt: str) -> str:
+        final_prompt = f"{prompt}\n\n다음 텍스트를 요약해줘:\n\n{text}"
+        pyperclip.copy(final_prompt)
+        webbrowser.open(self.chat_url)
+        return (
+            f"[클립보드 모드] 프롬프트가 클립보드에 복사되었습니다. "
+            f"{self.chat_url} 에서 붙여넣기 하세요."
+        )
+
+    @staticmethod
+    def default_model() -> str:
+        return "chatgpt"
+
+    @staticmethod
+    def available_models() -> list[tuple[str, str]]:
+        return [
+            ("chatgpt", "ChatGPT (웹)"),
+            ("claude-web", "Claude (웹)"),
+            ("grok-web", "Grok (웹)"),
+        ]

--- a/src/summarize_pipeline/providers/gemini_provider.py
+++ b/src/summarize_pipeline/providers/gemini_provider.py
@@ -1,0 +1,32 @@
+"""
+Google Gemini AI Provider
+"""
+
+from .base import AIProvider
+
+
+class GeminiProvider(AIProvider):
+    """Google Gemini API를 사용한 요약 엔진"""
+
+    def __init__(self, api_key: str, model_name: str = None):
+        import google.generativeai as genai
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(model_name or self.default_model())
+
+    def summarize(self, text: str, prompt: str) -> str:
+        full_prompt = f"{prompt}\n\n다음은 전체 텍스트입니다:\n{text}"
+        response = self.model.generate_content(full_prompt)
+        return response.text
+
+    @staticmethod
+    def default_model() -> str:
+        return "gemini-2.5-flash"
+
+    @staticmethod
+    def available_models() -> list[tuple[str, str]]:
+        return [
+            ("gemini-2.5-flash", "Gemini 2.5 Flash (추천)"),
+            ("gemini-2.5-pro", "Gemini 2.5 Pro"),
+            ("gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite"),
+            ("gemini-2.0-flash", "Gemini 2.0 Flash"),
+        ]

--- a/src/summarize_pipeline/providers/grok_provider.py
+++ b/src/summarize_pipeline/providers/grok_provider.py
@@ -1,0 +1,33 @@
+"""
+xAI Grok AI Provider (OpenAI SDK 호환 API)
+"""
+
+from .base import AIProvider
+
+
+class GrokProvider(AIProvider):
+    """xAI Grok API를 사용한 요약 엔진 (OpenAI SDK 호환)"""
+
+    def __init__(self, api_key: str, model_name: str = None):
+        from openai import OpenAI
+        self.client = OpenAI(api_key=api_key, base_url="https://api.x.ai/v1")
+        self.model_name = model_name or self.default_model()
+
+    def summarize(self, text: str, prompt: str) -> str:
+        full_prompt = f"{prompt}\n\n다음은 전체 텍스트입니다:\n{text}"
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[{"role": "user", "content": full_prompt}],
+        )
+        return response.choices[0].message.content
+
+    @staticmethod
+    def default_model() -> str:
+        return "grok-3"
+
+    @staticmethod
+    def available_models() -> list[tuple[str, str]]:
+        return [
+            ("grok-3", "Grok 3 (추천)"),
+            ("grok-3-mini", "Grok 3 Mini"),
+        ]

--- a/src/summarize_pipeline/providers/openai_provider.py
+++ b/src/summarize_pipeline/providers/openai_provider.py
@@ -1,0 +1,34 @@
+"""
+OpenAI AI Provider
+"""
+
+from .base import AIProvider
+
+
+class OpenAIProvider(AIProvider):
+    """OpenAI API를 사용한 요약 엔진"""
+
+    def __init__(self, api_key: str, model_name: str = None):
+        from openai import OpenAI
+        self.client = OpenAI(api_key=api_key)
+        self.model_name = model_name or self.default_model()
+
+    def summarize(self, text: str, prompt: str) -> str:
+        full_prompt = f"{prompt}\n\n다음은 전체 텍스트입니다:\n{text}"
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[{"role": "user", "content": full_prompt}],
+        )
+        return response.choices[0].message.content
+
+    @staticmethod
+    def default_model() -> str:
+        return "gpt-4o"
+
+    @staticmethod
+    def available_models() -> list[tuple[str, str]]:
+        return [
+            ("gpt-4o", "GPT-4o (추천)"),
+            ("gpt-4o-mini", "GPT-4o Mini"),
+            ("o3-mini", "o3-mini"),
+        ]

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.84.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -284,6 +303,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -707,9 +735,10 @@ wheels = [
 
 [[package]]
 name = "lms-summarizer"
-version = "1.4.1"
+version = "1.4.3"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "av" },
     { name = "flet", extra = ["all"] },
     { name = "google-generativeai" },
@@ -723,6 +752,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.84.0" },
     { name = "av", specifier = ">=13.0.0" },
     { name = "flet", extras = ["all"], specifier = ">=0.81.0,<1.0" },
     { name = "google-generativeai", specifier = ">=0.8.3" },


### PR DESCRIPTION
## Summary
- AI Provider 추상화 레이어 구축 (`providers/` 패키지): Gemini, OpenAI, Claude, Grok 통일 인터페이스
- Provider 팩토리 패턴으로 엔진별 인스턴스 생성
- GUI에 엔진+모델 2단 드롭다운 (EngineModelSelector) 추가
- API 키 없이 사용 모드: 클립보드 복사 + ChatGPT/Claude/Grok 웹 열기
- 엔진별 API 키 분리 저장 및 자동 복원

## Changes
- `src/summarize_pipeline/providers/` (신규 패키지) - AIProvider ABC + 5개 구현체
- `src/summarize_pipeline/pipeline.py` - engine/api_key 파라미터 추가
- `src/gui/components/model_selector.py` - 엔진+모델 2단 드롭다운으로 전환
- `src/gui/views/main_view.py` - 엔진 선택 연동, 클립보드 모드 처리
- `src/gui/workers/processing_worker.py` - engine 파라미터 전파
- `src/gui/core/file_manager.py` - 엔진별 API 키 저장/복원
- `src/gui/core/validators.py` - 클립보드 모드 시 API 키 검증 스킵
- `pyproject.toml` + `uv.lock` - anthropic SDK 의존성 추가

## Test plan
- [ ] Gemini 엔진 선택 후 기존처럼 요약이 동작하는지 확인
- [ ] OpenAI/Claude/Grok 엔진 선택 시 해당 모델 목록이 표시되는지 확인
- [ ] 엔진 변경 시 API 키 라벨이 업데이트되는지 확인
- [ ] 엔진별 API 키가 별도 저장/복원되는지 확인
- [ ] "API 키 없이 사용" 모드에서 클립보드 복사 + 웹 브라우저 열기 동작 확인
- [ ] 기존 저장된 Gemini API 키가 마이그레이션되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)