### PR TITLE
feat: 작업 완료 후 결과 폴더 열기 기능

### DIFF
--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -323,3 +323,26 @@ def clear_history() -> None:
     settings = load_settings()
     settings.pop("history", None)
     save_settings(settings)
+
+
+# ── 파일 탐색기 / 자동 열기 ─────────────────────────────
+
+def open_in_file_explorer(path: str) -> None:
+    """플랫폼별 파일 탐색기로 경로 열기"""
+    import subprocess, sys
+    if sys.platform == 'darwin':
+        subprocess.Popen(['open', path])
+    elif sys.platform == 'win32':
+        subprocess.Popen(['explorer', path])
+    else:
+        subprocess.Popen(['xdg-open', path])
+
+
+def get_auto_open_folder() -> bool:
+    return load_settings().get("auto_open_folder", False)
+
+
+def set_auto_open_folder(enabled: bool) -> None:
+    settings = load_settings()
+    settings["auto_open_folder"] = enabled
+    save_settings(settings)

--- a/src/gui/views/main_view.py
+++ b/src/gui/views/main_view.py
@@ -2,8 +2,6 @@
 메인 뷰 (Flet)
 """
 
-import subprocess
-import sys
 from typing import Dict, List
 
 import flet as ft
@@ -21,6 +19,7 @@ from src.gui.core.module_loader import check_required_modules
 from src.gui.core.file_manager import (
     ensure_downloads_directory, set_downloads_directory,
     save_user_inputs, load_user_inputs,
+    open_in_file_explorer,
 )
 from src.gui.components.input_field import InputField
 from src.gui.components.log_area import LogArea
@@ -275,13 +274,7 @@ class MainView:
     # ── 이벤트 핸들러 ──────────────────────────────────────
 
     def _open_in_finder(self, e=None):
-        path = ensure_downloads_directory()
-        if sys.platform == 'darwin':
-            subprocess.Popen(['open', path])
-        elif sys.platform == 'win32':
-            subprocess.Popen(['explorer', path])
-        else:
-            subprocess.Popen(['xdg-open', path])
+        open_in_file_explorer(ensure_downloads_directory())
 
     async def _change_path(self, e=None):
         path = await self._folder_picker.get_directory_path(

--- a/src/gui/views/progress_view.py
+++ b/src/gui/views/progress_view.py
@@ -5,6 +5,9 @@
 import flet as ft
 
 from src.gui.theme import Colors, Typography, Spacing, Radius, divider
+from src.gui.core.file_manager import (
+    open_in_file_explorer, ensure_downloads_directory, get_auto_open_folder,
+)
 
 # 처리 단계 정의
 _STEPS = [
@@ -85,6 +88,19 @@ class ProgressModal:
             on_click=self._toggle_log,
         )
 
+        # 결과 폴더 열기 버튼 (완료 시 표시)
+        self._open_folder_btn = ft.ElevatedButton(
+            content=ft.Text("결과 폴더 열기"),
+            icon=ft.Icons.FOLDER_OPEN,
+            on_click=self._handle_open_folder,
+            visible=False,
+            style=ft.ButtonStyle(
+                color=ft.Colors.WHITE,
+                bgcolor=Colors.SUCCESS,
+                shape=ft.RoundedRectangleBorder(radius=Radius.SM),
+            ),
+        )
+
         # 중지 버튼
         self._stop_btn = ft.ElevatedButton(
             content=ft.Text("중지"),
@@ -127,7 +143,7 @@ class ProgressModal:
                     tight=True,
                 ),
             ),
-            actions=[self._stop_btn],
+            actions=[self._open_folder_btn, self._stop_btn],
             actions_alignment=ft.MainAxisAlignment.END,
         )
 
@@ -148,6 +164,9 @@ class ProgressModal:
             self._log_toggle.content.value = "상세 로그 보기"
             self._log_toggle.icon = ft.Icons.EXPAND_MORE
         self._page.update()
+
+    def _handle_open_folder(self, e=None):
+        open_in_file_explorer(ensure_downloads_directory())
 
     def _handle_stop(self, e=None):
         if self._is_finished:
@@ -217,6 +236,9 @@ class ProgressModal:
         self._progress_bar.value = 1.0
         self._status_text.value = "모든 작업이 완료되었습니다!"
         self._status_text.color = Colors.SUCCESS
+        self._open_folder_btn.visible = True
+        if get_auto_open_folder():
+            open_in_file_explorer(ensure_downloads_directory())
         self._stop_btn.content.value = "닫기"
         self._stop_btn.disabled = False
         self._stop_btn.style = ft.ButtonStyle(

--- a/src/gui/views/settings_view.py
+++ b/src/gui/views/settings_view.py
@@ -11,6 +11,7 @@ from src.gui.core.file_manager import (
     get_summary_prompt, set_summary_prompt,
     get_chrome_path, set_chrome_path, detect_chrome_paths,
     get_debug_mode, set_debug_mode,
+    get_auto_open_folder, set_auto_open_folder,
 )
 
 
@@ -79,12 +80,18 @@ def open_settings_dialog(page: ft.Page):
         active_color=Colors.PRIMARY,
     )
 
+    auto_open_switch = ft.Switch(
+        value=get_auto_open_folder(),
+        active_color=Colors.PRIMARY,
+    )
+
     def _save(e):
         prompt = (prompt_field.value or "").strip()
         chrome_path = (chrome_field.value or "").strip()
 
         set_summary_prompt(prompt if prompt else DEFAULT_PROMPT)
         set_debug_mode(debug_switch.value)
+        set_auto_open_folder(auto_open_switch.value)
 
         if chrome_path:
             if not os.path.exists(chrome_path):
@@ -180,6 +187,27 @@ def open_settings_dialog(page: ft.Page):
                                 expand=True,
                             ),
                             debug_switch,
+                        ],
+                        alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                    ),
+                    divider(),
+                    # 완료 후 폴더 자동 열기 섹션
+                    ft.Row(
+                        controls=[
+                            ft.Column(
+                                controls=[
+                                    ft.Text("완료 후 폴더 자동 열기", size=Typography.BODY, weight=Typography.SEMI_BOLD),
+                                    ft.Text(
+                                        "작업 완료 시 결과 폴더를 자동으로 엽니다.",
+                                        size=Typography.SMALL,
+                                        color=Colors.TEXT_MUTED,
+                                    ),
+                                ],
+                                spacing=2,
+                                expand=True,
+                            ),
+                            auto_open_switch,
                         ],
                         alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
                         vertical_alignment=ft.CrossAxisAlignment.CENTER,


### PR DESCRIPTION
## Summary
- 플랫폼별 파일 탐색기 열기 유틸리티 추출 (macOS/Windows/Linux 지원)
- 작업 완료 후 Progress Modal에 "결과 폴더 열기" 버튼 추가
- 설정에 "완료 후 폴더 자동 열기" 토글 추가

## Changes
- `src/gui/core/file_manager.py` - `open_in_file_explorer()`, `get/set_auto_open_folder()` 추가
- `src/gui/views/main_view.py` - 기존 `_open_in_finder` 리팩토링 (공용 유틸리티 사용)
- `src/gui/views/progress_view.py` - 완료 시 "결과 폴더 열기" 버튼 표시 + 자동 열기
- `src/gui/views/settings_view.py` - 자동 열기 토글 스위치 추가

## Test plan
- [ ] 작업 완료 후 "결과 폴더 열기" 버튼이 표시되는지 확인
- [ ] 버튼 클릭 시 파일 탐색기가 열리는지 확인
- [ ] 설정에서 "완료 후 폴더 자동 열기" 토글이 동작하는지 확인
- [ ] 자동 열기 ON 시 완료 즉시 폴더가 열리는지 확인
- [ ] 메인 화면의 폴더 열기 버튼도 정상 동작하는지 확인 (리팩토링 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)