### PR TITLE
feat: AI 프로바이더 모델 업데이트 및 버그 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,18 @@
 
 | 엔진 | 지원 모델 | 비용 |
 | --- | --- | --- |
-| **Gemini** (Google) | 2.5 Flash (권장), 2.5 Pro, 2.5 Flash Lite, 2.0 Flash | 무료 티어 제공 |
-| **OpenAI** | GPT-4o (권장), GPT-4o Mini, o3-mini | 유료 |
-| **Claude** (Anthropic) | Claude Sonnet 4 (권장), Claude Haiku 4.5 | 유료 |
-| **Grok** (xAI) | Grok 3 (권장), Grok 3 Mini | 유료 |
-| **클립보드 모드** | ChatGPT / Claude / Grok 웹 | 무료 (API 키 불필요, 브라우저에서 수동 붙여넣기) |
+| **Gemini** (Google) | 2.5 Flash (권장), 2.5 Pro, 2.5 Flash Lite | 무료 티어 제공 |
+| **OpenAI** | GPT-5.4 (권장), GPT-5 Mini, GPT-4o, GPT-4o Mini | 유료 |
+| **Claude** (Anthropic) | Claude Sonnet 4.6 (권장), Claude Haiku 4.5 | 유료 |
+| **Grok** (xAI) | Grok 4.1 Fast (권장), Grok 4.1 Fast Reasoning, Grok 3 | 유료 |
+| **클립보드 모드** | Gemini / ChatGPT / Claude / Grok 웹 | 무료 (API 키 불필요, 브라우저에서 수동 붙여넣기) |
+
+> ⚠️ **모델 목록은 각 AI 공급자의 최신 상황에 따라 달라질 수 있습니다.** 사용 가능한 모델이 변경되었거나 오류가 발생하는 경우, 각 공급자의 공식 문서를 확인하세요.
+>
+> - [Gemini 모델](https://ai.google.dev/gemini-api/docs/models)
+> - [OpenAI 모델](https://developers.openai.com/api/docs/models)
+> - [Claude 모델](https://platform.claude.com/docs/en/about-claude/models/overview)
+> - [Grok 모델](https://docs.x.ai/developers/models)
 
 ### 기타 기능
 

--- a/src/gui/components/left_panel/ai_settings.py
+++ b/src/gui/components/left_panel/ai_settings.py
@@ -75,11 +75,10 @@ class AISettingsSection:
         self._api_field.set_enabled(not is_clipboard)
         self._clipboard_notice.visible = is_clipboard
 
-        # 엔진별 저장된 API 키 복원
+        # 엔진별 저장된 API 키 복원 (없으면 필드 비움)
         if not is_clipboard:
             saved_key = get_api_key_for_engine(engine)
-            if saved_key:
-                self._api_field.set_value(saved_key)
+            self._api_field.set_value(saved_key)
 
         if self._api_field.control.page:
             self._api_field.control.update()

--- a/src/summarize_pipeline/providers/claude_provider.py
+++ b/src/summarize_pipeline/providers/claude_provider.py
@@ -24,11 +24,11 @@ class ClaudeProvider(AIProvider):
 
     @staticmethod
     def default_model() -> str:
-        return "claude-sonnet-4-20250514"
+        return "claude-sonnet-4-6"
 
     @staticmethod
     def available_models() -> list[tuple[str, str]]:
         return [
-            ("claude-sonnet-4-20250514", "Claude Sonnet 4 (추천)"),
-            ("claude-haiku-4-5-20241022", "Claude Haiku 4.5"),
+            ("claude-sonnet-4-6", "Claude Sonnet 4.6 (추천)"),
+            ("claude-haiku-4-5", "Claude Haiku 4.5"),
         ]

--- a/src/summarize_pipeline/providers/clipboard_provider.py
+++ b/src/summarize_pipeline/providers/clipboard_provider.py
@@ -12,9 +12,10 @@ from .base import AIProvider
 
 
 CHATBOT_URLS = {
-    "chatgpt": "https://chat.openai.com/chat",
-    "claude-web": "https://claude.ai/new",
-    "grok-web": "https://x.com/i/grok",
+    "gemini-web": "https://gemini.google.com/app",
+    "chatgpt": "https://chatgpt.com/",
+    "claude-web": "https://claude.ai/",
+    "grok-web": "https://grok.com/",
 }
 
 
@@ -41,6 +42,7 @@ class ClipboardProvider(AIProvider):
     @staticmethod
     def available_models() -> list[tuple[str, str]]:
         return [
+            ("gemini-web", "Gemini (웹)"),
             ("chatgpt", "ChatGPT (웹)"),
             ("claude-web", "Claude (웹)"),
             ("grok-web", "Grok (웹)"),

--- a/src/summarize_pipeline/providers/gemini_provider.py
+++ b/src/summarize_pipeline/providers/gemini_provider.py
@@ -31,5 +31,4 @@ class GeminiProvider(AIProvider):
             ("gemini-2.5-flash", "Gemini 2.5 Flash (추천)"),
             ("gemini-2.5-pro", "Gemini 2.5 Pro"),
             ("gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite"),
-            ("gemini-2.0-flash", "Gemini 2.0 Flash"),
         ]

--- a/src/summarize_pipeline/providers/grok_provider.py
+++ b/src/summarize_pipeline/providers/grok_provider.py
@@ -23,11 +23,13 @@ class GrokProvider(AIProvider):
 
     @staticmethod
     def default_model() -> str:
-        return "grok-3"
+        return "grok-4-1-fast-non-reasoning"
 
     @staticmethod
     def available_models() -> list[tuple[str, str]]:
         return [
-            ("grok-3", "Grok 3 (추천)"),
+            ("grok-4-1-fast-non-reasoning", "Grok 4.1 Fast (추천)"),
+            ("grok-4-1-fast-reasoning", "Grok 4.1 Fast Reasoning"),
+            ("grok-3", "Grok 3"),
             ("grok-3-mini", "Grok 3 Mini"),
         ]

--- a/src/summarize_pipeline/providers/openai_provider.py
+++ b/src/summarize_pipeline/providers/openai_provider.py
@@ -23,12 +23,13 @@ class OpenAIProvider(AIProvider):
 
     @staticmethod
     def default_model() -> str:
-        return "gpt-4o"
+        return "gpt-5.4"
 
     @staticmethod
     def available_models() -> list[tuple[str, str]]:
         return [
-            ("gpt-4o", "GPT-4o (추천)"),
+            ("gpt-5.4", "GPT-5.4 (추천)"),
+            ("gpt-5-mini-2025-08-07", "GPT-5 Mini"),
+            ("gpt-4o", "GPT-4o"),
             ("gpt-4o-mini", "GPT-4o Mini"),
-            ("o3-mini", "o3-mini"),
         ]


### PR DESCRIPTION
## Summary
- AI 프로바이더 모델 목록을 각 공급자 공식 문서 기준으로 최신화 (Gemini, OpenAI, Claude, Grok)
- 클립보드 모드에 Gemini 웹 추가 및 챗봇 URL 업데이트
- AI 엔진 전환 시 이전 엔진의 API 키가 필드에 남아있는 버그 수정
- README.md 모델 목록 반영 및 공급자별 공식 문서 링크 추가

## Test plan
- [ ] 각 AI 엔진(Gemini, OpenAI, Claude, Grok) 선택 시 모델 드롭다운에 최신 모델이 표시되는지 확인
- [ ] 엔진 전환 시 API 키 필드가 해당 엔진의 저장된 키로 교체되거나 비워지는지 확인
- [ ] 클립보드 모드에서 Gemini 웹 선택 시 gemini.google.com으로 연결되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)