### PR TITLE
fix: distil-large-v3 한국어 미지원 모델 제거 및 small 경량 모델 추가

### DIFF
--- a/.tasks/done/2026-W16/distil-model-korean-broken.md
+++ b/.tasks/done/2026-W16/distil-model-korean-broken.md
@@ -37,6 +37,12 @@ depends_on: []
 
 ## 체크리스트
 
-- [ ] 방안 결정 (A: 제거 / B: 경고)
-- [ ] model_manager.py 수정
-- [ ] stt_settings.py UI 반영
+- [x] 방안 결정 (A: 제거 / B: 경고) → A. 제거 선택
+- [x] model_manager.py 수정 — distil-large-v3 제거, small(461MB) 경량 모델로 교체
+- [x] stt_settings.py UI 반영 — 동적 렌더링으로 자동 반영
+
+## 결과
+
+- distil-large-v3 제거됨 (한국어 미지원, 속도 이점 없음)
+- `small`(461MB) 경량 모델 추가 — 저사양/CPU 환경용
+- 모델 체계: 표준(large-v3-turbo) → 경량(small) → 고정밀(large-v3)

--- a/src/audio_pipeline/model_manager.py
+++ b/src/audio_pipeline/model_manager.py
@@ -14,25 +14,25 @@ FW_MODEL_REGISTRY: dict[str, dict] = {
         "source": "hf_auto",
         "hf_model": "large-v3-turbo",
     },
-    "distil-large-v3": {
-        "label": "고속 모드",
-        "emoji": "⚡",
-        "description": "2~3배 빠른 인식, 정확도 거의 동일",
-        "size_mb": 760,
+    "small": {
+        "label": "경량 모드",
+        "emoji": "🪶",
+        "description": "빠른 인식, 저사양/CPU 환경에 적합 (461MB)",
+        "size_mb": 461,
         "source": "hf_auto",
-        "hf_model": "distil-large-v3",
+        "hf_model": "small",
     },
     "large-v3": {
         "label": "고정밀 모드",
         "emoji": "💎",
-        "description": "최고 정확도 (속도 느림)",
+        "description": "최고 정확도 (속도 느림, 3.1GB)",
         "size_mb": 3100,
         "source": "hf_auto",
         "hf_model": "large-v3",
     },
 }
 
-FW_MODE_ORDER = ["large-v3-turbo", "distil-large-v3", "large-v3"]
+FW_MODE_ORDER = ["large-v3-turbo", "small", "large-v3"]
 
 
 def is_available(model_key: str, engine: str = "faster-whisper") -> bool:


### PR DESCRIPTION
## Summary
- distil-large-v3 모델 제거 (한국어 STT hallucination, 속도 이점 미미)
- small (461MB) 경량 모델 추가 — 저사양/CPU 환경 대응
- 모델 체계 정리: 표준(large-v3-turbo) → 경량(small) → 고정밀(large-v3)

## Testing
- [ ] GUI에서 STT 설정에 3개 모델 표시 확인
- [ ] small 모델 선택 후 STT 실행 시 정상 동작
- [ ] 기존 large-v3-turbo, large-v3 동작에 영향 없음

## Risks
- 기존에 distil-large-v3를 사용 중이던 사용자는 설정 초기화 필요 (기본값 large-v3-turbo로 자동 폴백)