### PR TITLE
feat: OpenAI Whisper API 클라우드 STT 엔진 추가

### DIFF
--- a/src/audio_pipeline/transcriber.py
+++ b/src/audio_pipeline/transcriber.py
@@ -34,6 +34,9 @@ def transcribe_audio_to_text(audio_path: str, txt_path: str, engine="faster-whis
             model_name=model_name, device=device, compute_type=compute_type,
             params=params, on_log=on_log,
         )
+    elif engine == "openai-whisper":
+        api_key = params.pop("api_key", None)
+        transcriber = OpenAIWhisperTranscriber(api_key=api_key, on_log=on_log)
     elif engine == "returnzero":
         transcriber = ReturnZeroTranscriber()
     else:
@@ -151,6 +154,39 @@ class FasterWhisperTranscriber(Transcriber):
         self._on_log(f"[faster-whisper] 변환 완료: {txt_path}")
         self._on_log(f"[faster-whisper] 소요 시간: {elapsed:.1f}초")
         self._on_log(f"[faster-whisper] 감지 언어: {info.language} ({info.language_probability:.0%})")
+
+
+class OpenAIWhisperTranscriber(Transcriber):
+    """OpenAI Whisper API 기반 클라우드 STT (로컬 모델 다운로드 불필요)"""
+
+    def __init__(self, api_key: str = None, on_log=None):
+        from openai import OpenAI
+        self._on_log = on_log or (lambda msg: None)
+        if not api_key:
+            raise ValueError("OpenAI Whisper API 키가 필요합니다.")
+        self.client = OpenAI(api_key=api_key)
+        self._on_log("[openai-whisper] 클라우드 STT 엔진 초기화 완료")
+
+    def transcribe(self, audio_path: str, txt_path: str):
+        self._on_log(f"[openai-whisper] 클라우드 STT 시작: {audio_path}")
+        transcribe_start = time.time()
+
+        with open(audio_path, "rb") as audio_file:
+            response = self.client.audio.transcriptions.create(
+                model="whisper-1",
+                file=audio_file,
+                language="ko",
+                response_format="text",
+            )
+
+        text = response if isinstance(response, str) else response.text
+
+        with open(txt_path, "w", encoding="utf-8") as f:
+            f.write(text)
+
+        elapsed = time.time() - transcribe_start
+        self._on_log(f"[openai-whisper] 변환 완료: {txt_path}")
+        self._on_log(f"[openai-whisper] 소요 시간: {elapsed:.1f}초")
 
 
 class ReturnZeroTranscriber(Transcriber):

--- a/src/gui/components/left_panel/stt_settings.py
+++ b/src/gui/components/left_panel/stt_settings.py
@@ -14,6 +14,7 @@ from src.gui.core.file_manager import (
 
 _STT_ENGINE_OPTIONS = [
     ("faster-whisper", "faster-whisper (로컬, GPU 지원)"),
+    ("openai-whisper", "OpenAI Whisper API (클라우드, $0.006/분)"),
     ("returnzero", "ReturnZero API (유료)"),
 ]
 
@@ -168,6 +169,37 @@ class STTSettingsSection:
             tooltip="ReturnZero API 키를 client_id:client_secret 형식으로 입력하세요",
         )
 
+        # ── OpenAI Whisper API 키 ──────────────────────────
+        self._openai_stt_key_field = ft.TextField(
+            value=get_stt_api_key(engine="openai-whisper"),
+            hint_text="sk-...",
+            border_radius=Radius.SM, border_color=Colors.BORDER,
+            focused_border_color=Colors.PRIMARY, text_size=Typography.BODY,
+            label="OpenAI API 키",
+            label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
+            prefix_icon=ft.Icons.KEY,
+            visible=(current_stt == "openai-whisper"),
+            dense=True,
+            password=True,
+            can_reveal_password=True,
+            tooltip="OpenAI Whisper API에 사용할 API 키를 입력하세요",
+        )
+
+        # ── OpenAI Whisper 안내 ────────────────────────────
+        self._openai_whisper_notice = ft.Container(
+            content=ft.Text(
+                "클라우드 STT — 로컬 모델 다운로드 없이 빠른 음성 인식\n"
+                "요금: $0.006/분 (OpenAI 계정 필요)",
+                size=Typography.SMALL,
+                color="#1D4ED8",
+            ),
+            bgcolor="#EFF6FF",
+            border=ft.border.all(1, "#BFDBFE"),
+            border_radius=Radius.SM,
+            padding=ft.padding.symmetric(horizontal=10, vertical=6),
+            visible=(current_stt == "openai-whisper"),
+        )
+
         # ── 엔진 드롭다운 ──────────────────────────────────
         self._engine_dd = ft.Dropdown(
             options=[ft.dropdown.Option(key=k, text=t) for k, t in _STT_ENGINE_OPTIONS],
@@ -197,6 +229,8 @@ class STTSettingsSection:
             controls=[
                 self._engine_dd,
                 self._fw_section,
+                self._openai_whisper_notice,
+                self._openai_stt_key_field,
                 self._rtzr_api_field,
                 self._save_btn,
             ],
@@ -216,6 +250,8 @@ class STTSettingsSection:
         engine = get_stt_engine()
         if engine == "returnzero":
             return "ReturnZero API"
+        if engine == "openai-whisper":
+            return "OpenAI Whisper API (클라우드)"
         model = get_stt_model()
         from src.audio_pipeline.model_manager import FW_MODEL_REGISTRY
         info = FW_MODEL_REGISTRY.get(model)
@@ -274,8 +310,12 @@ class STTSettingsSection:
         engine = self._engine_dd.value or "faster-whisper"
         self._fw_section.visible = (engine == "faster-whisper")
         self._rtzr_api_field.visible = (engine == "returnzero")
+        self._openai_stt_key_field.visible = (engine == "openai-whisper")
+        self._openai_whisper_notice.visible = (engine == "openai-whisper")
         self._fw_section.update()
         self._rtzr_api_field.update()
+        self._openai_stt_key_field.update()
+        self._openai_whisper_notice.update()
         self._summary.value = self._get_summary_text()
         try:
             if self._summary.page:
@@ -288,6 +328,12 @@ class STTSettingsSection:
         set_stt_engine(engine)
         if engine == "returnzero":
             set_stt_api_key((self._rtzr_api_field.value or "").strip())
+        elif engine == "openai-whisper":
+            set_stt_api_key((self._openai_stt_key_field.value or "").strip(), engine="openai-whisper")
+            # openai-whisper STT 파라미터에 API 키 전달
+            params = get_stt_params()
+            params["api_key"] = (self._openai_stt_key_field.value or "").strip()
+            set_stt_params(params)
         elif engine == "faster-whisper":
             set_stt_model(self._fw_selected_mode[0])
             try:

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -327,15 +327,23 @@ def set_stt_params(params: dict) -> None:
     save_settings(settings)
 
 
-def get_stt_api_key() -> str:
-    """ReturnZero STT API 키(client_id:client_secret 형식) 반환"""
-    return load_settings().get("stt_api_key", "")
-
-
-def set_stt_api_key(api_key: str) -> None:
-    """ReturnZero STT API 키를 settings.json에 저장"""
+def get_stt_api_key(engine: str = None) -> str:
+    """STT API 키 반환. engine 지정 시 해당 엔진별 키, 미지정 시 ReturnZero 호환."""
     settings = load_settings()
-    settings["stt_api_key"] = api_key
+    if engine:
+        return settings.get("stt_api_keys", {}).get(engine, "")
+    return settings.get("stt_api_key", "")
+
+
+def set_stt_api_key(api_key: str, engine: str = None) -> None:
+    """STT API 키를 settings.json에 저장. engine 지정 시 엔진별 저장."""
+    settings = load_settings()
+    if engine:
+        keys = settings.get("stt_api_keys", {})
+        keys[engine] = api_key
+        settings["stt_api_keys"] = keys
+    else:
+        settings["stt_api_key"] = api_key
     save_settings(settings)
 
 

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -372,6 +372,10 @@ class ProcessingWorker:
         self._emit_log(Messages.AUDIO_CONVERTING)
 
         audio_pipeline = self.modules['AudioToTextPipeline'](engine=self.stt_engine, model_name=self.stt_model, stt_params=self.stt_params, on_log=self._emit_log)
+        # OpenAI Whisper 클라우드 STT인 경우 API 키를 파라미터에 주입
+        if self.stt_engine == "openai-whisper":
+            from src.gui.core.file_manager import get_stt_api_key
+            self.stt_params["api_key"] = get_stt_api_key(engine="openai-whisper")
         self._emit_log(f"STT 엔진: {self.stt_engine} / 모델: {self.stt_model}")
         text_paths = []
 


### PR DESCRIPTION
## Summary
- OpenAI Whisper API 기반 클라우드 STT 엔진 추가
- 로컬 모델 다운로드 불필요 — API 키만으로 즉시 사용 가능
- 요금: $0.006/분 (기존 faster-whisper 800MB 모델 다운로드 불필요)
- 엔진별 API 키 저장 지원 (settings.json의 stt_api_keys 컬렉션)

## Testing
- [ ] STT 설정에서 OpenAI Whisper API 엔진 선택 가능
- [ ] API 키 입력 후 저장/복원 동작
- [ ] 실제 오디오 파일 STT 변환 정상 동작
- [ ] 기존 faster-whisper, ReturnZero 엔진에 영향 없음

## Risks
- OpenAI API 키가 없으면 사용 불가 (무료 API 아님)
- 대용량 파일의 경우 업로드 시간이 소요될 수 있음