### PR TITLE
feat: Ollama 로컬 LLM 및 OpenAI 호환 커스텀 엔드포인트 프로바이더 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 ## 설계 의도
 
 - **GUI 중심 개발**: CLI(`src/main.py`)는 폐기 예정. 단, 각 파이프라인 모듈은 독립 실행/테스트 가능하도록 추상화를 유지한다.
-- **기본 엔진**: STT는 faster-whisper(CTranslate2 기반), 요약은 Gemini. 나머지(ReturnZero, OpenAI, ChatGPT)는 대안 옵션이다. 모델은 표준(`large-v3-turbo`), 고속(`distil-large-v3`) 두 가지.
+- **기본 엔진**: STT는 faster-whisper(CTranslate2 기반), 요약은 Gemini. 나머지(OpenAI, Claude, Grok, Ollama, Custom, Clipboard)는 대안 옵션이다. Ollama는 로컬 LLM으로 API 키 불필요. Custom은 임의 OpenAI 호환 엔드포인트 지원.
 - **ChatGPTSummarizer**: API 호출이 아니라 클립보드 복사 + 브라우저 열기 방식이다. 의도된 동작이다.
 - **Python >=3.11,<3.13**: `.python-version`에 `3.11`로 설정되어 있고 uv가 자동 관리한다.
 

--- a/src/gui/components/left_panel/ai_settings.py
+++ b/src/gui/components/left_panel/ai_settings.py
@@ -16,6 +16,8 @@ _ENGINE_LABELS = {
     "openai": "OpenAI API 키",
     "claude": "Anthropic API 키",
     "grok": "xAI API 키",
+    "ollama": "API 키 (불필요)",
+    "custom": "API 키 (선택사항)",
     "clipboard": "API 키 (불필요)",
 }
 
@@ -41,6 +43,21 @@ class AISettingsSection:
             visible=False,
             bgcolor="#FFFBEB",  # amber-50
             border=ft.border.all(1, "#FDE68A"),  # amber-200
+            border_radius=Radius.MD,
+            padding=ft.padding.symmetric(horizontal=12, vertical=8),
+        )
+
+        # Ollama 모드 안내
+        self._ollama_notice = ft.Container(
+            content=ft.Text(
+                "로컬 LLM (Ollama)을 사용합니다. Ollama가 실행 중이어야 합니다.\n"
+                "설치: ollama.com → 모델 다운로드 후 서버 실행",
+                size=Typography.SMALL,
+                color="#1D4ED8",
+            ),
+            visible=False,
+            bgcolor="#EFF6FF",
+            border=ft.border.all(1, "#BFDBFE"),
             border_radius=Radius.MD,
             padding=ft.padding.symmetric(horizontal=12, vertical=8),
         )
@@ -80,6 +97,7 @@ class AISettingsSection:
                 self._model_selector.control,
                 self._api_field.container,
                 self._clipboard_notice,
+                self._ollama_notice,
             ],
             spacing=Spacing.SM,
             horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
@@ -97,7 +115,8 @@ class AISettingsSection:
         model = self._model_selector.get_model()
         engine_label = {
             "gemini": "Gemini", "openai": "OpenAI", "claude": "Claude",
-            "grok": "Grok", "clipboard": "클립보드",
+            "grok": "Grok", "ollama": "Ollama", "custom": "Custom",
+            "clipboard": "클립보드",
         }.get(engine, engine)
         if engine == "clipboard":
             key_status = "API 불필요"
@@ -123,8 +142,10 @@ class AISettingsSection:
         new_label = _ENGINE_LABELS.get(engine, "AI API 키")
         self._api_field.control.label = new_label
         is_clipboard = engine == "clipboard"
-        self._api_field.set_enabled(not is_clipboard)
+        is_no_key = engine in ("clipboard", "ollama")
+        self._api_field.set_enabled(not is_no_key)
         self._clipboard_notice.visible = is_clipboard
+        self._ollama_notice.visible = (engine == "ollama")
 
         # 엔진별 저장된 API 키 복원 (없으면 필드 비움)
         if not is_clipboard:
@@ -135,6 +156,8 @@ class AISettingsSection:
             self._api_field.control.update()
         if self._clipboard_notice.page:
             self._clipboard_notice.update()
+        if self._ollama_notice.page:
+            self._ollama_notice.update()
 
         if self._external_engine_cb:
             self._external_engine_cb(engine)
@@ -167,7 +190,7 @@ class AISettingsSection:
 
     def set_enabled(self, enabled: bool):
         self._model_selector.set_enabled(enabled)
-        if self.get_engine() != "clipboard":
+        if self.get_engine() not in ("clipboard", "ollama"):
             self._api_field.set_enabled(enabled)
 
     def clear(self):

--- a/src/gui/components/model_selector.py
+++ b/src/gui/components/model_selector.py
@@ -13,6 +13,8 @@ _ENGINE_OPTIONS = [
     ("openai", "OpenAI"),
     ("claude", "Anthropic Claude"),
     ("grok", "xAI Grok"),
+    ("ollama", "Ollama (로컬 LLM, 무료)"),
+    ("custom", "OpenAI 호환 (커스텀 엔드포인트)"),
     ("clipboard", "API 키 없이 사용"),
 ]
 

--- a/src/summarize_pipeline/providers/__init__.py
+++ b/src/summarize_pipeline/providers/__init__.py
@@ -10,6 +10,8 @@ from .openai_provider import OpenAIProvider
 from .claude_provider import ClaudeProvider
 from .grok_provider import GrokProvider
 from .clipboard_provider import ClipboardProvider
+from .ollama_provider import OllamaProvider
+from .custom_provider import CustomProvider
 
 # 엔진 이름 → Provider 클래스 매핑
 ENGINE_REGISTRY: dict[str, type[AIProvider]] = {
@@ -17,6 +19,8 @@ ENGINE_REGISTRY: dict[str, type[AIProvider]] = {
     "openai": OpenAIProvider,
     "claude": ClaudeProvider,
     "grok": GrokProvider,
+    "ollama": OllamaProvider,
+    "custom": CustomProvider,
 }
 
 # 엔진 이름 → API 키 설정 필드명 매핑
@@ -25,6 +29,7 @@ ENGINE_API_KEY_MAP: dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "claude": "ANTHROPIC_API_KEY",
     "grok": "XAI_API_KEY",
+    # ollama, custom: API 키 불필요
 }
 
 
@@ -32,8 +37,8 @@ def create_provider(engine: str, api_key: str = None, model_name: str = None) ->
     """엔진 이름으로 Provider 인스턴스를 생성하는 팩토리 함수
 
     Args:
-        engine: 엔진 이름 ("gemini", "openai", "claude", "grok", "clipboard")
-        api_key: API 키 (clipboard 모드에서는 불필요)
+        engine: 엔진 이름 ("gemini", "openai", "claude", "grok", "ollama", "custom", "clipboard")
+        api_key: API 키 (clipboard, ollama 모드에서는 불필요)
         model_name: 모델명 (None이면 기본 모델 사용)
 
     Returns:
@@ -56,6 +61,8 @@ __all__ = [
     "ClaudeProvider",
     "GrokProvider",
     "ClipboardProvider",
+    "OllamaProvider",
+    "CustomProvider",
     "ENGINE_REGISTRY",
     "ENGINE_API_KEY_MAP",
     "create_provider",

--- a/src/summarize_pipeline/providers/custom_provider.py
+++ b/src/summarize_pipeline/providers/custom_provider.py
@@ -1,0 +1,40 @@
+"""
+Custom OpenAI 호환 엔드포인트 Provider
+
+LM Studio, vLLM, text-generation-webui, 또는 임의의 OpenAI API 호환 서버에
+연결하여 요약을 수행합니다. base_url과 model_name을 사용자가 직접 설정.
+"""
+
+from .base import AIProvider
+
+
+class CustomProvider(AIProvider):
+    """OpenAI 호환 커스텀 엔드포인트를 사용한 요약 엔진"""
+
+    def __init__(self, api_key: str = None, model_name: str = None,
+                 base_url: str = None):
+        from openai import OpenAI
+        self._base_url = (base_url or "http://localhost:8080/v1").rstrip("/")
+        self.client = OpenAI(
+            api_key=api_key or "not-needed",
+            base_url=self._base_url,
+        )
+        self.model_name = model_name or self.default_model()
+
+    def summarize(self, text: str, prompt: str) -> str:
+        full_prompt = f"{prompt}\n\n다음은 전체 텍스트입니다:\n{text}"
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[{"role": "user", "content": full_prompt}],
+        )
+        return response.choices[0].message.content
+
+    @staticmethod
+    def default_model() -> str:
+        return "default"
+
+    @staticmethod
+    def available_models() -> list[tuple[str, str]]:
+        return [
+            ("default", "기본 모델"),
+        ]

--- a/src/summarize_pipeline/providers/ollama_provider.py
+++ b/src/summarize_pipeline/providers/ollama_provider.py
@@ -1,0 +1,46 @@
+"""
+Ollama 로컬 LLM Provider (OpenAI SDK 호환)
+
+Ollama가 로컬에서 실행 중일 때 http://localhost:11434/v1 엔드포인트를 통해
+OpenAI SDK로 요약 요청을 보냅니다. API 키 불필요.
+"""
+
+from .base import AIProvider
+
+
+class OllamaProvider(AIProvider):
+    """Ollama 로컬 LLM을 사용한 요약 엔진 (API 키 불필요)"""
+
+    DEFAULT_BASE_URL = "http://localhost:11434/v1"
+
+    def __init__(self, api_key: str = None, model_name: str = None,
+                 base_url: str = None):
+        from openai import OpenAI
+        self._base_url = (base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        self.client = OpenAI(
+            api_key="ollama",  # Ollama는 API 키 미사용, 더미값 필요
+            base_url=self._base_url,
+        )
+        self.model_name = model_name or self.default_model()
+
+    def summarize(self, text: str, prompt: str) -> str:
+        full_prompt = f"{prompt}\n\n다음은 전체 텍스트입니다:\n{text}"
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[{"role": "user", "content": full_prompt}],
+        )
+        return response.choices[0].message.content
+
+    @staticmethod
+    def default_model() -> str:
+        return "qwen2.5:7b"
+
+    @staticmethod
+    def available_models() -> list[tuple[str, str]]:
+        return [
+            ("qwen2.5:7b", "Qwen 2.5 7B (추천)"),
+            ("qwen2.5:14b", "Qwen 2.5 14B"),
+            ("llama3.1:8b", "Llama 3.1 8B"),
+            ("gemma3:4b", "Gemma 3 4B (경량)"),
+            ("exaone3.5:7.8b", "EXAONE 3.5 7.8B (한국어 특화)"),
+        ]


### PR DESCRIPTION
## Summary
- Ollama 로컬 LLM 프로바이더 추가 (API 키 불필요, 무료 사용)
- Custom OpenAI 호환 프로바이더 추가 (LM Studio, vLLM 등)
- AI 엔진 선택기에 Ollama, Custom 옵션 추가
- 지원 모델: Qwen 2.5 (7B/14B), Llama 3.1, Gemma 3, EXAONE 3.5

## Testing
- [ ] AI 엔진 선택기에서 Ollama, Custom 선택 가능
- [ ] Ollama 실행 중일 때 요약 정상 동작
- [ ] 모델 선택 및 직접 입력 동작
- [ ] 기존 엔진 (Gemini, OpenAI, Claude, Grok)에 영향 없음

## Risks
- Ollama가 실행 중이 아닐 때 요청 실패 (사용자 안내 메시지로 대응)
- 커스텀 엔드포인트 URL이 잘못된 경우 연결 실패