### PR TITLE
fix: faster-whisper 오디오 파이프라인 버그 및 AI 모델 선택기 버그 수정 (v1.9.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@
 
 - **패키지 매니저**: uv 사용. 의존성 추가는 `uv add`, 설치는 `uv sync`.
 - PyInstaller 빌드 시 faster-whisper(CTranslate2) + PyAV 포함. 모델은 런타임 다운로드이므로 번들 크기 감소.
+- PyInstaller 빌드에서 **torch는 excludes에 명시적 제외**됨 (~275MB 절감). 따라서 CUDA 감지는 `ctranslate2` 내장 API와 `nvidia-smi` 명령에 의존.
+- PyInstaller 빌드 시 `faster_whisper/assets/silero_vad_v6.onnx`를 datas에 포함해야 VAD 필터가 동작함 (미포함 시 VAD 자동 비활성화).
 - Chrome 경로가 Mac용(`/Applications/Google Chrome.app/...`)으로 하드코딩되어 있다. Windows 배포 시 경로 분기 필요.
 
 ## 커밋 메시지 컨벤션

--- a/lms-summarizer.spec
+++ b/lms-summarizer.spec
@@ -36,6 +36,15 @@ datas = [
 if certifi_cacert:
     datas.append((certifi_cacert, "certifi"))
 
+# faster_whisper VAD(silero) ONNX 모델 포함
+try:
+    import faster_whisper
+    fw_assets = os.path.join(os.path.dirname(faster_whisper.__file__), "assets")
+    if os.path.isdir(fw_assets):
+        datas.append((fw_assets, "faster_whisper/assets"))
+except ImportError:
+    pass
+
 binaries = []
 
 a = Analysis(

--- a/src/audio_pipeline/converter.py
+++ b/src/audio_pipeline/converter.py
@@ -2,19 +2,22 @@ import os
 import av
 
 
-def convert_mp4_to_wav(mp4_path: str, wav_path: str, sample_rate: int = 16000):
-    # PyAV를 사용하여 MP4에서 오디오를 추출, mono WAV로 변환
-    if not os.path.exists(mp4_path):
-        raise FileNotFoundError(f"입력 파일이 존재하지 않음: {mp4_path}")
+def convert_audio_to_wav(input_path: str, wav_path: str, sample_rate: int = 16000):
+    """오디오/비디오 파일을 mono WAV로 변환.
+
+    PyAV를 사용하므로 MP4, MP3, MKV, WebM 등 PyAV가 지원하는 모든 포맷을 처리합니다.
+    """
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"입력 파일이 존재하지 않음: {input_path}")
 
     os.makedirs(os.path.dirname(wav_path), exist_ok=True)
 
     try:
-        input_container = av.open(mp4_path)
+        input_container = av.open(input_path)
         output_container = av.open(wav_path, mode='w')
 
         if not input_container.streams.audio:
-            raise RuntimeError(f"오디오 스트림이 없음: {mp4_path}")
+            raise RuntimeError(f"오디오 스트림이 없음: {input_path}")
 
         output_stream = output_container.add_stream('pcm_s16le', rate=sample_rate)
         output_stream.layout = 'mono'
@@ -34,3 +37,7 @@ def convert_mp4_to_wav(mp4_path: str, wav_path: str, sample_rate: int = 16000):
         input_container.close()
     except av.AVError as e:
         raise RuntimeError(f"오디오 변환 오류: {e}")
+
+
+# 하위 호환성 유지
+convert_mp4_to_wav = convert_audio_to_wav

--- a/src/audio_pipeline/pipeline.py
+++ b/src/audio_pipeline/pipeline.py
@@ -13,18 +13,19 @@ class AudioToTextPipeline:
         self.stt_params = stt_params or {}
         self.on_log = on_log
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
+        self._cached_transcriber = None  # 모델 로드 캐싱 (다중 파일 처리 시 재사용)
 
-    def convert_to_wav(self, mp4_path: str) -> str:
-        """MP4 파일을 WAV로 변환하고 WAV 경로를 반환"""
-        from src.audio_pipeline.converter import convert_mp4_to_wav
+    def convert_to_wav(self, input_path: str) -> str:
+        """오디오/비디오 파일을 WAV로 변환하고 WAV 경로를 반환"""
+        from src.audio_pipeline.converter import convert_audio_to_wav
 
-        filename = Path(mp4_path).stem
+        filename = Path(input_path).stem
         wav_path = os.path.join(self.downloads_dir, f"{filename}.wav")
         os.makedirs(self.downloads_dir, exist_ok=True)
 
-        print(f"[INFO] WAV 변환 시작: {mp4_path}")
+        print(f"[INFO] WAV 변환 시작: {input_path}")
         start_time = time.time()
-        convert_mp4_to_wav(mp4_path, wav_path, self.sample_rate)
+        convert_audio_to_wav(input_path, wav_path, self.sample_rate)
         elapsed = time.time() - start_time
         print(f"[DONE] WAV 변환 완료: {wav_path} ({elapsed:.1f}초)")
 
@@ -41,7 +42,12 @@ class AudioToTextPipeline:
 
         print(f"[INFO] STT 변환 시작: {wav_path}")
         start_time = time.time()
-        transcribe_audio_to_text(wav_path, txt_path, engine=self.engine, model_name=self.model_name, params=self.stt_params, on_log=self.on_log)
+        self._cached_transcriber = transcribe_audio_to_text(
+            wav_path, txt_path,
+            engine=self.engine, model_name=self.model_name,
+            params=self.stt_params, on_log=self.on_log,
+            _reuse_transcriber=self._cached_transcriber,
+        )
         elapsed = time.time() - start_time
         print(f"[DONE] 텍스트 저장 완료: {txt_path} ({elapsed:.1f}초)")
 
@@ -54,15 +60,12 @@ class AudioToTextPipeline:
 
         return txt_path
 
-    def process(self, mp4_path: str, remove_wav: bool = True) -> str:
-        """MP4 → WAV → 텍스트 전체 파이프라인 (하위 호환성 유지)"""
-        if not mp4_path.endswith(".mp4"):
-            raise ValueError("mp4 파일만 처리 가능합니다.")
-
-        print(f"[INFO] 변환 시작: {mp4_path}")
+    def process(self, input_path: str, remove_wav: bool = True) -> str:
+        """오디오/비디오 → WAV → 텍스트 전체 파이프라인 (하위 호환성 유지)"""
+        print(f"[INFO] 변환 시작: {input_path}")
         start_time = time.time()
 
-        wav_path = self.convert_to_wav(mp4_path)
+        wav_path = self.convert_to_wav(input_path)
         txt_path = self.transcribe(wav_path, remove_wav=remove_wav)
 
         end_time = time.time()

--- a/src/audio_pipeline/transcriber.py
+++ b/src/audio_pipeline/transcriber.py
@@ -1,5 +1,7 @@
 import json
 import re
+import subprocess
+import sys
 import time
 from abc import ABC, abstractmethod
 import os
@@ -21,24 +23,49 @@ def clean_transcript(text: str, repeat_threshold: int = 4) -> str:
     return re.sub(pattern, r'\1', text)
 
 
-def transcribe_audio_to_text(audio_path: str, txt_path: str, engine="faster-whisper", model_name="large-v3-turbo", params=None, on_log=None):
-    """오디오/비디오 파일을 텍스트로 변환"""
+def transcribe_audio_to_text(
+    audio_path: str,
+    txt_path: str,
+    engine="faster-whisper",
+    model_name="large-v3-turbo",
+    params=None,
+    on_log=None,
+    _reuse_transcriber=None,
+):
+    """오디오/비디오 파일을 텍스트로 변환.
+
+    Args:
+        _reuse_transcriber: 이전 호출에서 반환된 Transcriber 인스턴스.
+            전달하면 모델 재로드를 생략하여 성능이 크게 향상됩니다.
+
+    Returns:
+        사용된 Transcriber 인스턴스 (다음 호출 시 _reuse_transcriber로 전달)
+    """
     _log = on_log or (lambda msg: None)
     params = dict(params or {})
     repeat_threshold = int(params.pop("repeat_threshold", 4))
 
     if engine == "faster-whisper":
-        device = params.pop("device", "auto")
-        compute_type = params.pop("compute_type", "auto")
-        transcriber = FasterWhisperTranscriber(
-            model_name=model_name, device=device, compute_type=compute_type,
-            params=params, on_log=on_log,
-        )
+        if _reuse_transcriber is not None:
+            transcriber = _reuse_transcriber
+        else:
+            device = params.pop("device", "auto")
+            compute_type = params.pop("compute_type", "auto")
+            transcriber = FasterWhisperTranscriber(
+                model_name=model_name, device=device, compute_type=compute_type,
+                params=params, on_log=on_log,
+            )
     elif engine == "openai-whisper":
-        api_key = params.pop("api_key", None)
-        transcriber = OpenAIWhisperTranscriber(api_key=api_key, on_log=on_log)
+        if _reuse_transcriber is not None:
+            transcriber = _reuse_transcriber
+        else:
+            api_key = params.pop("api_key", None)
+            transcriber = OpenAIWhisperTranscriber(api_key=api_key, on_log=on_log)
     elif engine == "returnzero":
-        transcriber = ReturnZeroTranscriber()
+        if _reuse_transcriber is not None:
+            transcriber = _reuse_transcriber
+        else:
+            transcriber = ReturnZeroTranscriber()
     else:
         raise ValueError("지원하지 않는 엔진입니다")
 
@@ -53,6 +80,8 @@ def transcribe_audio_to_text(audio_path: str, txt_path: str, engine="faster-whis
             with open(txt_path, "w", encoding="utf-8") as f:
                 f.write(cleaned)
             _log(f"[후처리] 반복 구문 제거 완료 (임계값: {repeat_threshold}회)")
+
+    return transcriber
 
 
 # 하위 호환성 유지
@@ -73,6 +102,17 @@ class FasterWhisperTranscriber(Transcriber):
         self._language = (params or {}).get("language", "ko")
         self._initial_prompt = (params or {}).get("initial_prompt", "한국어 강의입니다.")
         self._vad_filter = bool((params or {}).get("vad_filter", True))
+
+        # VAD(silero) ONNX 파일 가용성 확인 — PyInstaller 빌드 환경에서 누락 가능
+        if self._vad_filter:
+            vad_available = self._check_vad_available()
+            if not vad_available:
+                self._vad_filter = False
+                self._on_log(
+                    "⚠️ [faster-whisper] silero VAD 모델 파일 없음 — VAD 필터 비활성화됨\n"
+                    "   (음성 구간 탐지가 꺼져서 전체 구간을 처리하므로 속도가 느려질 수 있습니다)\n"
+                    "   PyInstaller 빌드 시 faster_whisper/assets/ 디렉토리를 포함하면 VAD가 활성화됩니다."
+                )
 
         resolved_device, resolved_compute = self._resolve_device(device, compute_type, self._on_log)
         self._on_log(f"[faster-whisper] 모델 로드 중: {model_name} (device={resolved_device}, compute_type={resolved_compute})")
@@ -95,35 +135,76 @@ class FasterWhisperTranscriber(Transcriber):
         self._on_log(f"[faster-whisper] 모델 로드 완료: {self.model_load_sec:.1f}초 (device={resolved_device})")
 
     @staticmethod
+    def _check_vad_available() -> bool:
+        """silero VAD ONNX 모델 파일이 존재하는지 확인.
+
+        PyInstaller 빌드 환경에서 faster_whisper/assets/ 디렉토리가 누락될 수 있어
+        VAD 활성화 전에 파일 존재 여부를 검사합니다.
+        """
+        try:
+            import faster_whisper
+            assets_dir = os.path.join(os.path.dirname(faster_whisper.__file__), "assets")
+            silero_path = os.path.join(assets_dir, "silero_vad_v6.onnx")
+            return os.path.isfile(silero_path)
+        except Exception:
+            return False
+
+    @staticmethod
     def _resolve_device(device: str, compute_type: str, on_log=None) -> tuple:
         """device='auto'일 때 CUDA 가용 여부를 판단하여 실제 디바이스를 결정.
 
         faster-whisper(CTranslate2)는 CUDA(NVIDIA)만 GPU 가속을 지원함.
         Apple Silicon(M1~M5), Intel Arc, AMD 내장 GPU는 CUDA 미지원 → CPU 폴백.
+
+        감지 우선순위:
+        1. ctranslate2 내장 CUDA 지원 확인 (가장 신뢰도 높음)
+        2. torch.cuda.is_available() (torch 설치 시)
+        3. nvidia-smi 시스템 명령 (드라이버만 있어도 감지)
         """
         _log = on_log or print
 
         if device != "auto":
             return device, compute_type
 
+        # 1. ctranslate2 자체 CUDA 감지 (가장 신뢰도 높음 — 실제 사용 라이브러리)
+        try:
+            import ctranslate2
+            compute_types = ctranslate2.get_supported_compute_types("cuda")
+            if compute_types:
+                gpu_info = f"CTranslate2 CUDA 지원 (types: {', '.join(compute_types)})"
+                _log(f"[faster-whisper] CUDA GPU 감지: {gpu_info}")
+                return "cuda", compute_type if compute_type != "auto" else "float16"
+        except (ValueError, RuntimeError):
+            # ctranslate2 CUDA 빌드가 아닌 경우 ValueError 발생
+            pass
+        except Exception as e:
+            _log(f"[faster-whisper] ctranslate2 CUDA 확인 중 예외 (무시): {e}")
+
+        # 2. PyTorch CUDA 감지 (torch 설치 시)
         try:
             import torch
             if torch.cuda.is_available():
                 gpu_name = torch.cuda.get_device_name(0)
-                _log(f"[faster-whisper] CUDA GPU 감지: {gpu_name}")
+                _log(f"[faster-whisper] CUDA GPU 감지 (torch): {gpu_name}")
                 return "cuda", compute_type if compute_type != "auto" else "float16"
         except ImportError:
             pass
 
-        # ctranslate2 자체 CUDA 감지 시도
+        # 3. nvidia-smi 시스템 명령 (드라이버 설치 여부만 확인)
         try:
-            import ctranslate2
-            if "cuda" in ctranslate2.get_supported_compute_types("cuda"):
-                return "cuda", compute_type if compute_type != "auto" else "float16"
-        except Exception:
+            result = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                gpu_name = result.stdout.strip().split("\n")[0]
+                _log(f"[faster-whisper] NVIDIA GPU 감지 (nvidia-smi): {gpu_name}")
+                _log("[faster-whisper] ⚠️ ctranslate2/torch에서 CUDA를 감지하지 못했습니다.")
+                _log("[faster-whisper] CUDA Toolkit 또는 ctranslate2 CUDA 빌드 버전이 필요합니다.")
+                _log("[faster-whisper] → https://developer.nvidia.com/cuda-downloads 참조")
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             pass
 
-        import sys
         if sys.platform == "darwin":
             _log("[faster-whisper] macOS 감지 — Apple Silicon은 CUDA 미지원, CPU 모드 사용")
         else:

--- a/src/gui/components/left_panel/__init__.py
+++ b/src/gui/components/left_panel/__init__.py
@@ -61,6 +61,7 @@ class LeftPanel:
     def get_all_inputs(self) -> Dict[str, str]:
         values = self.account.get_values()
         values['api_key'] = self.ai_settings.get_api_key()
+        values['base_url'] = self.ai_settings.get_base_url()
         return values
 
     def set_enabled(self, enabled: bool):
@@ -83,3 +84,5 @@ class LeftPanel:
             self.ai_settings.set_engine(saved['ai_engine'])
         if 'ai_model' in saved:
             self.ai_settings.set_model(saved['ai_model'])
+        if 'base_url' in saved and saved['base_url']:
+            self.ai_settings.set_base_url(saved['base_url'])

--- a/src/gui/components/left_panel/ai_settings.py
+++ b/src/gui/components/left_panel/ai_settings.py
@@ -1,5 +1,5 @@
 """
-AI 설정 섹션 - 엔진/모델 선택 + API 키 입력
+AI 설정 섹션 - 엔진/모델 선택 + API 키 입력 + 엔드포인트 URL
 """
 
 import flet as ft
@@ -8,7 +8,7 @@ from src.gui.theme import Colors, Typography, Spacing, Radius
 from src.gui.config.settings import INPUT_FIELD_CONFIGS
 from src.gui.components.input_field import InputField
 from src.gui.components.model_selector import EngineModelSelector
-from src.gui.core.file_manager import get_api_key_for_engine
+from src.gui.core.file_manager import get_api_key_for_engine, get_base_url_for_engine
 
 
 _ENGINE_LABELS = {
@@ -21,9 +21,12 @@ _ENGINE_LABELS = {
     "clipboard": "API 키 (불필요)",
 }
 
+# base_url 입력이 필요한 엔진
+_URL_ENGINES = {"ollama", "custom"}
+
 
 class AISettingsSection:
-    """AI 엔진 + 모델 + API 키 통합 섹션"""
+    """AI 엔진 + 모델 + API 키 + 엔드포인트 URL 통합 섹션"""
 
     def __init__(self, on_engine_change=None):
         self._external_engine_cb = on_engine_change
@@ -31,6 +34,21 @@ class AISettingsSection:
         self._api_field = InputField(INPUT_FIELD_CONFIGS['api_key'])
         self._model_selector = EngineModelSelector(
             on_engine_change=self._handle_engine_change,
+        )
+
+        # 엔드포인트 URL 입력 (Ollama / Custom 전용)
+        self._base_url_field = ft.TextField(
+            label="엔드포인트 URL",
+            hint_text="http://localhost:11434/v1",
+            prefix_icon=ft.Icons.LINK,
+            border_radius=Radius.SM,
+            border_color=Colors.BORDER,
+            focused_border_color=Colors.PRIMARY,
+            text_size=Typography.BODY,
+            label_style=ft.TextStyle(size=Typography.CAPTION, color=Colors.TEXT_SECONDARY),
+            tooltip="OpenAI 호환 API 엔드포인트 URL",
+            visible=False,
+            dense=True,
         )
 
         # 클립보드 모드 안내 (HTML: bg-amber-50 border-amber-200)
@@ -96,6 +114,7 @@ class AISettingsSection:
             controls=[
                 self._model_selector.control,
                 self._api_field.container,
+                self._base_url_field,
                 self._clipboard_notice,
                 self._ollama_notice,
             ],
@@ -138,7 +157,7 @@ class AISettingsSection:
         self._chevron.update()
 
     def _handle_engine_change(self, engine: str):
-        """엔진 변경 시 API 키 라벨/활성 상태 업데이트"""
+        """엔진 변경 시 API 키 라벨/활성 상태 + 엔드포인트 URL 표시 업데이트"""
         new_label = _ENGINE_LABELS.get(engine, "AI API 키")
         self._api_field.control.label = new_label
         is_clipboard = engine == "clipboard"
@@ -146,6 +165,19 @@ class AISettingsSection:
         self._api_field.set_enabled(not is_no_key)
         self._clipboard_notice.visible = is_clipboard
         self._ollama_notice.visible = (engine == "ollama")
+
+        # 엔드포인트 URL 필드 표시/숨김
+        show_url = engine in _URL_ENGINES
+        self._base_url_field.visible = show_url
+        if show_url:
+            # 엔진별 기본 URL 힌트 설정
+            if engine == "ollama":
+                self._base_url_field.hint_text = "http://localhost:11434/v1"
+            else:
+                self._base_url_field.hint_text = "http://localhost:8080/v1"
+            # 저장된 URL 복원
+            saved_url = get_base_url_for_engine(engine)
+            self._base_url_field.value = saved_url
 
         # 엔진별 저장된 API 키 복원 (없으면 필드 비움)
         if not is_clipboard:
@@ -158,6 +190,8 @@ class AISettingsSection:
             self._clipboard_notice.update()
         if self._ollama_notice.page:
             self._ollama_notice.update()
+        if self._base_url_field.page:
+            self._base_url_field.update()
 
         if self._external_engine_cb:
             self._external_engine_cb(engine)
@@ -179,6 +213,13 @@ class AISettingsSection:
     def get_api_key(self) -> str:
         return self._api_field.get_value()
 
+    def get_base_url(self) -> str:
+        """현재 엔진의 엔드포인트 URL 반환 (빈 값이면 Provider 기본값 사용)"""
+        engine = self.get_engine()
+        if engine not in _URL_ENGINES:
+            return ""
+        return (self._base_url_field.value or "").strip()
+
     def set_engine(self, engine: str):
         self._model_selector.set_engine(engine)
 
@@ -188,10 +229,18 @@ class AISettingsSection:
     def set_api_key(self, key: str):
         self._api_field.set_value(key)
 
+    def set_base_url(self, url: str):
+        """엔드포인트 URL 설정"""
+        self._base_url_field.value = url
+        self._base_url_field.visible = True
+
     def set_enabled(self, enabled: bool):
         self._model_selector.set_enabled(enabled)
         if self.get_engine() not in ("clipboard", "ollama"):
             self._api_field.set_enabled(enabled)
+        if self.get_engine() in _URL_ENGINES:
+            self._base_url_field.disabled = not enabled
 
     def clear(self):
         self._api_field.clear()
+        self._base_url_field.value = ""

--- a/src/gui/core/file_manager.py
+++ b/src/gui/core/file_manager.py
@@ -132,7 +132,7 @@ def extract_urls_from_input(url_input: str) -> List[str]:
     return urls
 
 
-_PERSISTABLE_FIELDS = ['student_id', 'api_key', 'ai_model', 'ai_engine']
+_PERSISTABLE_FIELDS = ['student_id', 'api_key', 'ai_model', 'ai_engine', 'base_url']
 
 
 def save_user_inputs(inputs: Dict[str, str]) -> None:
@@ -152,8 +152,16 @@ def save_user_inputs(inputs: Dict[str, str]) -> None:
         api_keys[engine] = api_key
     saved['api_keys'] = api_keys
 
+    # 엔진별 base_url 저장 (ollama, custom만 해당)
+    base_url = inputs.get('base_url', '')
+    base_urls = settings.get('base_urls', {})
+    if base_url:
+        base_urls[engine] = base_url
+    saved['base_urls'] = base_urls
+
     settings['user_inputs'] = saved
     settings['api_keys'] = api_keys
+    settings['base_urls'] = base_urls
     save_settings(settings)
 
 
@@ -176,6 +184,13 @@ def load_user_inputs() -> Dict[str, str]:
         saved['api_key'] = api_keys[engine]
 
     saved['api_keys'] = api_keys
+
+    # 엔진별 base_url 복원
+    base_urls = settings.get('base_urls', saved.get('base_urls', {}))
+    if base_urls.get(engine):
+        saved['base_url'] = base_urls[engine]
+    saved['base_urls'] = base_urls
+
     return saved
 
 
@@ -184,6 +199,13 @@ def get_api_key_for_engine(engine: str) -> str:
     settings = load_settings()
     api_keys = settings.get('api_keys', {})
     return api_keys.get(engine, '')
+
+
+def get_base_url_for_engine(engine: str) -> str:
+    """특정 엔진의 저장된 엔드포인트 URL 반환"""
+    settings = load_settings()
+    base_urls = settings.get('base_urls', {})
+    return base_urls.get(engine, '')
 
 
 def get_downloads_dir() -> str:

--- a/src/gui/views/main_view.py
+++ b/src/gui/views/main_view.py
@@ -150,14 +150,16 @@ class MainView:
 
         # 검증
         if start_stage == PipelineStage.DOWNLOAD:
+            # clipboard, ollama, custom은 API 키 불필요
+            skip_key = engine in ("clipboard", "ollama", "custom")
             valid, error_message = InputValidator.validate_all_inputs(
-                inputs, skip_api_key=(engine == "clipboard"),
+                inputs, skip_api_key=skip_key,
             )
             if not valid:
                 self._show_snackbar(error_message, Colors.ERROR)
                 return
         else:
-            if start_stage <= PipelineStage.SUMMARIZE and engine != "clipboard":
+            if start_stage <= PipelineStage.SUMMARIZE and engine not in ("clipboard", "ollama", "custom"):
                 valid, error = InputValidator.validate_api_key(inputs.get('api_key', ''))
                 if not valid:
                     self._show_snackbar(error, Colors.ERROR)
@@ -246,6 +248,7 @@ class MainView:
             save_video_dir=save_video_dir,
             model_name=model_name,
             engine=engine,
+            base_url=inputs.get('base_url', ''),
             on_log=invoke_on_ui(self.page, on_log),
             on_finished=on_finished,
             on_step_changed=invoke_on_ui(self.page, on_step),

--- a/src/gui/workers/processing_worker.py
+++ b/src/gui/workers/processing_worker.py
@@ -50,6 +50,7 @@ class ProcessingWorker:
         save_video_dir: str = None,
         model_name: str = "gemini-2.5-flash",
         engine: str = "gemini",
+        base_url: str = "",
         on_log: Optional[Callable[[str], None]] = None,
         on_finished: Optional[Callable[[bool, str], None]] = None,
         on_step_changed: Optional[Callable[[int, str], None]] = None,
@@ -62,6 +63,7 @@ class ProcessingWorker:
         self.save_video_dir = save_video_dir
         self.model_name = model_name
         self.engine = engine
+        self.base_url = base_url
         self.summary_prompt = get_summary_prompt()
         self.chrome_path = get_chrome_path()
         self.debug_mode = get_debug_mode()
@@ -421,6 +423,7 @@ class ProcessingWorker:
             prompt=self.summary_prompt,
             engine=self.engine,
             api_key=api_key,
+            base_url=self.base_url,
         )
         summary_paths = []
 

--- a/src/summarize_pipeline/pipeline.py
+++ b/src/summarize_pipeline/pipeline.py
@@ -17,12 +17,14 @@ class SummarizePipeline:
         prompt: str = None,
         engine: str = "gemini",
         api_key: str = None,
+        base_url: str = None,
     ):
         self.downloads_dir = None  # 다운로드 경로는 나중에 설정됨
         self.model_name = model_name
         self.prompt = prompt or _DEFAULT_PROMPT
         self.engine = engine
         self.api_key = api_key
+        self.base_url = base_url
 
     def process(self, text_path: str) -> str:
         """텍스트 요약"""
@@ -39,7 +41,7 @@ class SummarizePipeline:
             content = f.read()
 
         # Provider를 통해 요약 생성
-        provider = create_provider(self.engine, api_key=self.api_key, model_name=self.model_name)
+        provider = create_provider(self.engine, api_key=self.api_key, model_name=self.model_name, base_url=self.base_url)
         summary = provider.summarize(content, self.prompt)
 
         end_time = time.time()

--- a/src/summarize_pipeline/providers/__init__.py
+++ b/src/summarize_pipeline/providers/__init__.py
@@ -33,13 +33,15 @@ ENGINE_API_KEY_MAP: dict[str, str] = {
 }
 
 
-def create_provider(engine: str, api_key: str = None, model_name: str = None) -> AIProvider:
+def create_provider(engine: str, api_key: str = None, model_name: str = None,
+                    base_url: str = None) -> AIProvider:
     """엔진 이름으로 Provider 인스턴스를 생성하는 팩토리 함수
 
     Args:
         engine: 엔진 이름 ("gemini", "openai", "claude", "grok", "ollama", "custom", "clipboard")
         api_key: API 키 (clipboard, ollama 모드에서는 불필요)
         model_name: 모델명 (None이면 기본 모델 사용)
+        base_url: 엔드포인트 URL (ollama, custom에서 사용)
 
     Returns:
         AIProvider 인스턴스
@@ -51,7 +53,11 @@ def create_provider(engine: str, api_key: str = None, model_name: str = None) ->
     if not cls:
         raise ValueError(f"지원하지 않는 엔진: {engine}")
 
-    return cls(api_key=api_key, model_name=model_name or cls.default_model())
+    kwargs = {"api_key": api_key, "model_name": model_name or cls.default_model()}
+    # ollama, custom에만 base_url 전달 (다른 Provider는 파라미터를 무시)
+    if base_url and engine in ("ollama", "custom"):
+        kwargs["base_url"] = base_url
+    return cls(**kwargs)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

v1.9.0에서 발견된 7개 버그를 수정합니다. 크게 두 가지 영역입니다.

### 🔧 오디오 파이프라인 (faster-whisper)

| 버그 | 심각도 | 설명 |
|------|--------|------|
| CUDA GPU 미감지 | 🔴 Critical | PyInstaller에서 torch가 제외되어 `torch.cuda.is_available()`이 항상 False 반환 → ctranslate2 → torch → nvidia-smi 3단계 감지로 교체 |
| VAD ONNX 누락 | 🔴 Critical | `silero_vad_v6.onnx`가 PyInstaller 번들에 미포함 → 자동 fallback + spec에 datas 추가 |
| MP3 입력 실패 | 🟡 High | `.mp4` 확장자만 허용하던 검증 제거, `convert_audio_to_wav`로 개명 |
| 모델 재로드 | 🟡 High | 다중 파일 처리 시 WhisperModel이 매번 재로드 → `_reuse_transcriber` 캐싱 |
| 광역 예외 처리 | 🟢 Low | `_resolve_device()`의 `except Exception` 축소 |

### 🔧 AI 모델 선택기

| 버그 | 심각도 | 설명 |
|------|--------|------|
| base_url 전달 누락 | 🔴 Critical | Custom/Ollama 엔진의 엔드포인트 URL이 Provider에 도달하지 않음 → 전체 체인에 base_url 파라미터 추가 + GUI 입력 필드 신설 |
| API 키 검증 차단 | 🟡 High | Ollama/Custom에서 불필요한 API 키 검증이 실행 시작을 차단 → skip_api_key 조건 확장 |

### 변경 파일 (12 files, +238/-48)

**오디오 파이프라인:**
- `src/audio_pipeline/transcriber.py` — CUDA 감지 재작성, VAD fallback, 모델 캐싱
- `src/audio_pipeline/converter.py` — MP3 등 전체 오디오 포맷 지원
- `src/audio_pipeline/pipeline.py` — 확장자 검증 제거, transcriber 캐싱
- `lms-summarizer.spec` — VAD ONNX assets 번들 포함

**AI 모델 선택기:**
- `src/gui/components/left_panel/ai_settings.py` — 엔드포인트 URL 입력 필드 추가
- `src/gui/components/left_panel/__init__.py` — base_url getter/setter 연결
- `src/gui/core/file_manager.py` — 엔진별 base_url 저장/복원
- `src/gui/views/main_view.py` — skip_api_key 확장, base_url 전달
- `src/gui/workers/processing_worker.py` — base_url 파라미터 추가
- `src/summarize_pipeline/pipeline.py` — base_url 수신 및 전달
- `src/summarize_pipeline/providers/__init__.py` — create_provider에 base_url 추가

## Testing

- [x] `py_compile` 구문 검증 — 수정된 7개 Python 파일 모두 통과
- [ ] Windows PyInstaller 빌드 후 CUDA GPU 환경에서 faster-whisper 정상 동작 확인 필요
- [ ] Custom/Ollama 엔진 선택 시 엔드포인트 URL 입력 필드 표시 확인 필요
- [ ] 엔드포인트 URL 변경 후 재시작 시 저장값 복원 확인 필요

## Risks

- **낮음**: `base_url` 파라미터는 `ollama`, `custom` 엔진에만 전달되며, 기존 Provider (gemini, openai, claude, grok)에는 영향 없음
- **낮음**: VAD fallback은 ONNX 파일 없을 때만 비활성화되며, 정상 빌드에서는 기존과 동일하게 동작
- **주의**: CUDA 감지 로직 변경은 `nvidia-smi` subprocess 호출이 추가됨 — 드물게 nvidia-smi 타임아웃 가능성 있으나 5초 제한 설정