### PR TITLE
fix: 버전 표시 vunknown 버그 수정 + v1.9.3

### DIFF
--- a/lms-summarizer.spec
+++ b/lms-summarizer.spec
@@ -16,7 +16,17 @@ import os
 from pathlib import Path
 
 APP_NAME = "LMS-Summarizer"
-APP_VERSION = "1.9.0"
+
+# pyproject.toml에서 버전 자동 읽기
+def _read_version():
+    try:
+        import tomllib
+        with open("pyproject.toml", "rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except Exception:
+        return "0.0.0"
+
+APP_VERSION = _read_version()
 
 # SSL 인증서 번들 경로 (PyInstaller에서 requests HTTPS 요청에 필요)
 def find_certifi_cacert():
@@ -32,6 +42,7 @@ certifi_cacert = find_certifi_cacert()
 datas = [
     ("src", "src"),
     ("assets", "assets"),
+    ("pyproject.toml", "."),  # 버전 정보 (src/__init__.py에서 읽음)
 ]
 if certifi_cacert:
     datas.append((certifi_cacert, "certifi"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lms-summarizer"
-version = "1.9.2"
+version = "1.9.3"
 description = "숭실대학교 LMS 강의 동영상 다운로드 및 AI 요약 도구"
 requires-python = ">=3.11,<3.13"
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,9 +4,45 @@ LMS 강의 다운로드 & 요약
 숭실대학교 LMS 연동
 """
 
-try:
-    from importlib.metadata import version as _pkg_version
-    __version__ = _pkg_version("lms-summarizer")
-except Exception:
-    __version__ = "unknown"
-__author__ = "LMS Summarizer Team" 
+import os
+import sys
+
+def _detect_version():
+    """버전 감지 — 다양한 실행 환경에서 안정적으로 버전을 반환.
+
+    우선순위:
+    1. pyproject.toml (개발 환경 + PyInstaller 빌드 모두)
+    2. importlib.metadata (pip install 환경)
+    3. 하드코딩 폴백 (절대 도달하면 안 됨)
+    """
+    # 1. pyproject.toml에서 읽기
+    #    - 개발: src/../pyproject.toml
+    #    - PyInstaller onedir: _internal/pyproject.toml (spec에서 datas에 포함)
+    try:
+        import tomllib
+        _here = os.path.dirname(os.path.abspath(__file__))
+        _candidates = [
+            os.path.join(_here, "..", "pyproject.toml"),
+        ]
+        # PyInstaller: sys._MEIPASS는 _internal/ 디렉토리
+        if hasattr(sys, "_MEIPASS"):
+            _candidates.append(os.path.join(sys._MEIPASS, "pyproject.toml"))
+        for _path in _candidates:
+            _path = os.path.normpath(_path)
+            if os.path.isfile(_path):
+                with open(_path, "rb") as _f:
+                    return tomllib.load(_f)["project"]["version"]
+    except Exception:
+        pass
+
+    # 2. pip 설치 환경
+    try:
+        from importlib.metadata import version as _pkg_version
+        return _pkg_version("lms-summarizer")
+    except Exception:
+        pass
+
+    return "0.0.0"
+
+__version__ = _detect_version()
+__author__ = "LMS Summarizer Team"


### PR DESCRIPTION
## 문제

1.9.0 이후 GUI 헤더에 버전이 `vunknown`으로 표시됨.

## 원인

`src/__init__.py`에서 `importlib.metadata.version("lms-summarizer")`로 버전을 가져오는데,
PyInstaller 빌드 환경에서는 pip 메타데이터가 없어 항상 `"unknown"`으로 폴백됨.

## 변경 사항

### `src/__init__.py` — 버전 감지 로직 재작성

| 우선순위 | 방식 | 환경 |
|----------|------|------|
| 1 | `pyproject.toml` 직접 읽기 | 개발 + PyInstaller |
| 2 | `importlib.metadata` | pip install |
| 3 | 하드코딩 폴백 | 절대 도달하면 안 됨 |

PyInstaller에서 `sys._MEIPASS` 경로도 탐색하도록 추가.

### `lms-summarizer.spec` — 2가지 변경

| 변경 | 설명 |
|------|------|
| `APP_VERSION` 자동 읽기 | 하드코딩 `"1.9.0"` → `pyproject.toml`에서 `tomllib`로 읽기 |
| `pyproject.toml`을 datas에 추가 | 번들에 포함 → `__init__.py`에서 읽을 수 있음 |

### `pyproject.toml`

- 버전 1.9.2 → 1.9.3

## 검증

```
$ python -c "from src import __version__; print(__version__)"
1.9.3

$ python -c "from src.gui.config.constants import APP_VERSION; print(APP_VERSION)"
v1.9.3
```